### PR TITLE
Fix regions being falsely identified as failed

### DIFF
--- a/cloudwatch-logs-retention-policy.sh
+++ b/cloudwatch-logs-retention-policy.sh
@@ -93,7 +93,7 @@ function GetRegions(){
 		echo "Begin GetRegions Function"
 	fi
 	AWSregions=$(aws ec2 describe-regions --output=json --profile $profile 2>&1)
-	if echo "$AWSregions" | egrep -iq "error|not"; then
+	if echo "$AWSregions" | egrep -iq "error"; then
 		fail "$AWSregions"
 	else
 		ParseRegions=$(echo "$AWSregions" | jq '.Regions | .[] | .RegionName'| cut -d \" -f2 | sort)


### PR DESCRIPTION
The CLI returns a list of regions with the field "OptInStatus": "opt-in-not-required" so the script marks them as failed.

<!---
Verify first that your issue/request is not already reported on GitHub.
Also test if the latest release, and master branch are affected too.
-->

#### Issue Type
<!--- Pick one below and delete the rest -->
 - Bug Report
 - Feature Request
 - Documentation Issue


#### Script Name
Name of the script, file or feature, do not include extra details here


#### AWS CLI Version
Paste verbatim output from `aws --version` between quotes below
```

```

#### AWS CLI Profile (if any)
This will be shown by running `aws configure list` or `cat ~/.aws/config` (do not share access_key or secret_key!)
```

```

#### AWS Default Region
```

```

#### AWS Default Output Type
```

```

#### OS / Environment
<!---
Mention the OS you are running the script from, and the OS you are
managing, or say "N/A" for anything that is not platform-specific.
Also mention the specific version of what you are trying to control.
-->
```

```

#### Summary
<!--- Explain the problem briefly -->


#### Steps to Reproduce
<!---
For bugs, show exactly how to reproduce the problem, using a minimal test-case.
For new features, show how the feature would be used.
-->


<!--- Paste examples or commands between quotes below -->
```bash

```

<!--- You can also paste gist.github.com links for larger files -->

#### Expected Results
<!--- What did you expect to happen when running the steps above? -->


##### Actual Results
<!--- What actually happened? If possible run with extra verbosity -->

<!--- Paste verbatim command output between quotes below -->
```

```
