### PR TITLE
Support optional AWS CLI profile selection across scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ The AWS CLI supports named profiles stored in the config and credentials files. 
 
 `$ aws configure --profile example`
 
+### Running scripts with a specific AWS profile
+
+AWS scripts in this repository now support profile selection in this order of precedence:
+
+1. `--profile <name>` passed to the script
+2. `AWS_PROFILE` environment variable
+3. Legacy first positional argument (for backward compatibility)
+4. AWS CLI default profile/credential chain when none of the above are set
+
+Examples:
+
+`$ ./cloudwatch-logs-search.sh --profile staging`
+
+`$ AWS_PROFILE=production ./cloudwatch-logs-search.sh`
+
+`$ ./cloudwatch-logs-search.sh legacy-profile-name`
+
 ### What is jq?
 
 jq is a lightweight and flexible command-line JSON processor.

--- a/aws-profile.sh
+++ b/aws-profile.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Shared AWS CLI profile argument handling for repository scripts.
+# Precedence: --profile flag > AWS_PROFILE env var > legacy first positional arg.
+
+function aws_profile_prepare_args() {
+	local explicit_profile=""
+
+	AWS_SCRIPT_LEGACY_ARGS=()
+
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--profile)
+				shift
+				if [ $# -eq 0 ] || [ -z "$1" ]; then
+					echo "Failure: Missing value for --profile." >&2
+					return 1
+				fi
+				explicit_profile="$1"
+				;;
+			--profile=*)
+				explicit_profile="${1#--profile=}"
+				if [ -z "$explicit_profile" ]; then
+					echo "Failure: Missing value for --profile." >&2
+					return 1
+				fi
+				;;
+			*)
+				AWS_SCRIPT_LEGACY_ARGS+=("$1")
+				;;
+		esac
+		shift
+	done
+
+	if [ -n "$explicit_profile" ]; then
+		AWS_SCRIPT_PROFILE="$explicit_profile"
+		AWS_SCRIPT_LEGACY_ARGS=("$explicit_profile" "${AWS_SCRIPT_LEGACY_ARGS[@]}")
+	elif [ -n "${AWS_PROFILE:-}" ]; then
+		AWS_SCRIPT_PROFILE="$AWS_PROFILE"
+	elif [ ${#AWS_SCRIPT_LEGACY_ARGS[@]} -gt 0 ]; then
+		AWS_SCRIPT_PROFILE="${AWS_SCRIPT_LEGACY_ARGS[0]}"
+	else
+		AWS_SCRIPT_PROFILE=""
+	fi
+}
+
+function aws() {
+	local selected_profile="${AWS_SCRIPT_PROFILE:-${profile:-}}"
+
+	if [ -n "$selected_profile" ]; then
+		command aws --profile "$selected_profile" "$@"
+	else
+		command aws "$@"
+	fi
+}

--- a/cloudfront-inprogress-status.sh
+++ b/cloudfront-inprogress-status.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script monitors CloudFront distributions for In-Progress Status and alerts when it has completed and is Deployed
 # Requires the AWS CLI and jq
 
@@ -57,7 +64,7 @@ fi
 
 # Check for Distributions
 function distributionsCheck(){
-	distributions=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .ARN')
+	distributions=$(aws cloudfront list-distributions 2>&1 | jq '.DistributionList | .Items | .[] | .ARN')
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "$distributions"
 	fi
@@ -74,8 +81,8 @@ function listInProgress(){
 	echo "Checking for In-Progress Status..."
 	HorizontalRule
 
-	inprogress=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | select(.Status == "InProgress") | .Id' | cut -d \" -f2)
-	name=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | select(.Status == "InProgress") | .Origins | .Items | .[] | .Id' | cut -d \" -f2)
+	inprogress=$(aws cloudfront list-distributions 2>&1 | jq '.DistributionList | .Items | .[] | select(.Status == "InProgress") | .Id' | cut -d \" -f2)
+	name=$(aws cloudfront list-distributions 2>&1 | jq '.DistributionList | .Items | .[] | select(.Status == "InProgress") | .Origins | .Items | .[] | .Id' | cut -d \" -f2)
 
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo inprogress "$inprogress"
@@ -96,7 +103,7 @@ function checkStatus(){
 		HorizontalRule
 		return 1
 	else
-		status=$(aws cloudfront get-distribution --id $inprogress --profile $profile 2>&1 | jq '.Distribution | .Status' | cut -d \" -f2)
+		status=$(aws cloudfront get-distribution --id $inprogress 2>&1 | jq '.Distribution | .Status' | cut -d \" -f2)
 
 		while [ $status = "InProgress" ]; do
 			HorizontalRule

--- a/cloudfront-invalidation-status.sh
+++ b/cloudfront-invalidation-status.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script monitors CloudFront distributions for cache invalidation status and alerts when it has completed
 # Requires the AWS CLI and jq
 
@@ -57,7 +64,7 @@ fi
 
 # Check for Distributions
 function distributionsCheck(){
-	distributions=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .ARN')
+	distributions=$(aws cloudfront list-distributions 2>&1 | jq '.DistributionList | .Items | .[] | .ARN')
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "$distributions"
 	fi
@@ -69,8 +76,8 @@ function distributionsCheck(){
 
 # List Distributions
 function listDistributions(){
-	distributions=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .Id' | cut -d \" -f2)
-	names=$(aws cloudfront list-distributions --profile $profile 2>&1 | jq '.DistributionList | .Items | .[] | .Origins | .Items | .[] | .Id' | cut -d \" -f2)
+	distributions=$(aws cloudfront list-distributions 2>&1 | jq '.DistributionList | .Items | .[] | .Id' | cut -d \" -f2)
+	names=$(aws cloudfront list-distributions 2>&1 | jq '.DistributionList | .Items | .[] | .Origins | .Items | .[] | .Id' | cut -d \" -f2)
 
 	if [ -z "$distributions" ]; then
 		echo "$distributions"
@@ -109,7 +116,7 @@ function listInvalidations(){
 		if [[ $DEBUGMODE = "1" ]]; then
 			echo "Debug distribution ID: $distributionid"
 		fi
-		invalidations=$(aws cloudfront list-invalidations --distribution-id $distributionid --profile $profile 2>&1 | jq '.InvalidationList | .Items | .[] | select(.Status != "Completed") | .Id' | cut -d \" -f2)
+		invalidations=$(aws cloudfront list-invalidations --distribution-id $distributionid 2>&1 | jq '.InvalidationList | .Items | .[] | select(.Status != "Completed") | .Id' | cut -d \" -f2)
 		if [[ $DEBUGMODE = "1" ]]; then
 			echo invalidations "$invalidations"
 		fi
@@ -134,7 +141,7 @@ function checkInvalidationstatus(){
 		while IFS= read -r invalidationid
 		do
 			echo Invalidation ID: $invalidationid
-			invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $distributionid --id $invalidationid --profile $profile 2>&1 | jq '.Invalidation | .Status' | cut -d \" -f2)
+			invalidationStatus=$(aws cloudfront get-invalidation --distribution-id $distributionid --id $invalidationid 2>&1 | jq '.Invalidation | .Status' | cut -d \" -f2)
 
 			while [ $invalidationStatus = "InProgress" ]; do
 				HorizontalRule

--- a/cloudwatch-create-alarms-statuscheckfailed.sh
+++ b/cloudwatch-create-alarms-statuscheckfailed.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will set CloudWatch StatusCheckFailed Alarms with Recovery Action for all running EC2 Instances in all regions available
 # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/UsingAlarmActions.html#AddingRecoverActions
 
@@ -80,7 +87,7 @@ check_command "jq"
 
 # # Verify ALARMACTION is setup with some alert mechanism
 # if [[ -z $ALARMACTION ]] || [[ "$ALARMACTION" == "arn:aws:sns:us-east-1:YOURACCOUNTNUMBER:YOURSNSALERTNAME" ]]; then
-# 	SNSTopics=$(aws sns list-topics --profile $profile 2>&1)
+# 	SNSTopics=$(aws sns list-topics 2>&1)
 # 	if [ ! $? -eq 0 ]; then
 # 		fail "$SNSTopics"
 # 	fi
@@ -114,7 +121,7 @@ function GetRegions(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin GetRegions Function"
 	fi
-	AWSregions=$(aws ec2 describe-regions --output=json --profile $profile 2>&1)
+	AWSregions=$(aws ec2 describe-regions --output=json 2>&1)
 	if echo "$AWSregions" | egrep -iq "error|not"; then
 		fail "$AWSregions"
 	else
@@ -153,7 +160,7 @@ function ListInstances(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin ListInstances Function"
 	fi
-	Instances=$(aws ec2 describe-instances --filters Name=instance-state-name,Values=running --region $Region --output=json --profile $profile 2>&1)
+	Instances=$(aws ec2 describe-instances --filters Name=instance-state-name,Values=running --region $Region --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$Instances"
 	else
@@ -193,7 +200,7 @@ function SetAlarms(){
 			echo "Instance: $InstanceID"
 			pause
 		fi
-		InstanceNameTag=$(aws ec2 describe-tags --filters Name=key,Values=Name Name=resource-id,Values="$InstanceID" --region $Region --output=json --profile $profile 2>&1)
+		InstanceNameTag=$(aws ec2 describe-tags --filters Name=key,Values=Name Name=resource-id,Values="$InstanceID" --region $Region --output=json 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$InstanceNameTag"
 		fi
@@ -219,13 +226,13 @@ function SetAlarms(){
 		fi
 		ALARMACTION="arn:aws:automate:$Region:ec2:recover"
 		if [[ $DEBUGMODE = "1" ]]; then
-			echo aws cloudwatch put-metric-alarm --alarm-name "$InstanceName - Status Check Failed - $InstanceID" --metric-name StatusCheckFailed --namespace AWS/EC2 --statistic Maximum --dimensions Name=InstanceId,Value="$InstanceID" --unit Count --period 300 --evaluation-periods 1 --threshold 1 --comparison-operator GreaterThanOrEqualToThreshold --alarm-actions \'"$ALARMACTION"\' --output=json --profile $profile --region $Region 2>&1
+			echo aws cloudwatch put-metric-alarm --alarm-name "$InstanceName - Status Check Failed - $InstanceID" --metric-name StatusCheckFailed --namespace AWS/EC2 --statistic Maximum --dimensions Name=InstanceId,Value="$InstanceID" --unit Count --period 300 --evaluation-periods 1 --threshold 1 --comparison-operator GreaterThanOrEqualToThreshold --alarm-actions \'"$ALARMACTION"\' --output=json --region $Region 2>&1
 		fi
-		SetAlarm=$(aws cloudwatch put-metric-alarm --alarm-name "$InstanceName - Status Check Failed - $InstanceID" --metric-name StatusCheckFailed --namespace AWS/EC2 --statistic Maximum --dimensions Name=InstanceId,Value="$InstanceID" --unit Count --period 300 --evaluation-periods 1 --threshold 1 --comparison-operator GreaterThanOrEqualToThreshold --alarm-actions "$ALARMACTION" --output=json --profile $profile --region $Region 2>&1)
+		SetAlarm=$(aws cloudwatch put-metric-alarm --alarm-name "$InstanceName - Status Check Failed - $InstanceID" --metric-name StatusCheckFailed --namespace AWS/EC2 --statistic Maximum --dimensions Name=InstanceId,Value="$InstanceID" --unit Count --period 300 --evaluation-periods 1 --threshold 1 --comparison-operator GreaterThanOrEqualToThreshold --alarm-actions "$ALARMACTION" --output=json --region $Region 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$SetAlarm"
 		fi
-		VerifyAlarm=$(aws cloudwatch describe-alarms --alarm-names "$InstanceName - Status Check Failed - $InstanceID" --output=json --profile $profile --region $Region 2>&1)
+		VerifyAlarm=$(aws cloudwatch describe-alarms --alarm-names "$InstanceName - Status Check Failed - $InstanceID" --output=json --region $Region 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$VerifyAlarm"
 		fi

--- a/cloudwatch-create-alarms-unhealthyhost.sh
+++ b/cloudwatch-create-alarms-unhealthyhost.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will set CloudWatch UnhealthyHost Alarms for all ELBs in all regions available
 # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/UsingAlarmActions.html#AddingRecoverActions
 
@@ -88,7 +95,7 @@ function GetRegions(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin GetRegions Function"
 	fi
-	AWSregions=$(aws ec2 describe-regions --output=json --profile $profile 2>&1)
+	AWSregions=$(aws ec2 describe-regions --output=json 2>&1)
 	if echo "$AWSregions" | egrep -iq "error|not"; then
 		fail "$AWSregions"
 	else
@@ -129,7 +136,7 @@ function ListELBs(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin ListELBs Function"
 	fi
-	ELBs=$(aws elb describe-load-balancers --region $Region --output=json --profile $profile 2>&1)
+	ELBs=$(aws elb describe-load-balancers --region $Region --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$ELBs"
 	else
@@ -154,7 +161,7 @@ function ListALBs(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin ListALBs Function"
 	fi
-	ALBs=$(aws elbv2 describe-load-balancers --region $Region --output=json --profile $profile 2>&1)
+	ALBs=$(aws elbv2 describe-load-balancers --region $Region --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$ALBs"
 	else
@@ -175,7 +182,7 @@ function ListALBs(){
 }
 
 function ListSNSTopics(){
-	SNSTopics=$(aws sns list-topics --region $Region --profile $profile 2>&1)
+	SNSTopics=$(aws sns list-topics --region $Region 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$SNSTopics"
 	fi
@@ -230,13 +237,13 @@ function SetAlarms(){
 			echo "Setting CloudWatch Alarm"
 			if [[ $DEBUGMODE = "1" ]]; then
 				echo "$ALARMACTION"
-				echo aws cloudwatch put-metric-alarm --alarm-name "$ELBName - ELB Unhealthy Hosts" --metric-name UnHealthyHostCount --namespace AWS/ELB --statistic Maximum --dimensions Name=LoadBalancerName,Value="$ELBName" --unit Count --period 300 --evaluation-periods 1 --threshold 0 --comparison-operator GreaterThanThreshold --alarm-actions \'"$ALARMACTION"\' --output=json --profile $profile --region $Region 2>&1
+				echo aws cloudwatch put-metric-alarm --alarm-name "$ELBName - ELB Unhealthy Hosts" --metric-name UnHealthyHostCount --namespace AWS/ELB --statistic Maximum --dimensions Name=LoadBalancerName,Value="$ELBName" --unit Count --period 300 --evaluation-periods 1 --threshold 0 --comparison-operator GreaterThanThreshold --alarm-actions \'"$ALARMACTION"\' --output=json --region $Region 2>&1
 			fi
-			SetAlarm=$(aws cloudwatch put-metric-alarm --alarm-name "$ELBName - ELB Unhealthy Hosts" --metric-name UnHealthyHostCount --namespace AWS/ELB --statistic Maximum --dimensions Name=LoadBalancerName,Value="$ELBName" --unit Count --period 300 --evaluation-periods 1 --threshold 0 --comparison-operator GreaterThanThreshold --alarm-actions "$ALARMACTION" --output=json --profile $profile --region $Region 2>&1)
+			SetAlarm=$(aws cloudwatch put-metric-alarm --alarm-name "$ELBName - ELB Unhealthy Hosts" --metric-name UnHealthyHostCount --namespace AWS/ELB --statistic Maximum --dimensions Name=LoadBalancerName,Value="$ELBName" --unit Count --period 300 --evaluation-periods 1 --threshold 0 --comparison-operator GreaterThanThreshold --alarm-actions "$ALARMACTION" --output=json --region $Region 2>&1)
 			if [ ! $? -eq 0 ]; then
 				fail "$SetAlarm"
 			fi
-			VerifyAlarm=$(aws cloudwatch describe-alarms --alarm-names "$ELBName - ELB Unhealthy Hosts" --output=json --profile $profile --region $Region 2>&1)
+			VerifyAlarm=$(aws cloudwatch describe-alarms --alarm-names "$ELBName - ELB Unhealthy Hosts" --output=json --region $Region 2>&1)
 			if [ ! $? -eq 0 ]; then
 				fail "$VerifyAlarm"
 			fi
@@ -263,13 +270,13 @@ function SetAlarms(){
 			echo "Setting CloudWatch Alarm"
 			if [[ $DEBUGMODE = "1" ]]; then
 				echo "$ALARMACTION"
-				echo aws cloudwatch put-metric-alarm --alarm-name "$ALBName - ALB Unhealthy Hosts" --metric-name UnHealthyHostCount --namespace AWS/ApplicationELB --statistic Maximum --dimensions Name=LoadBalancerName,Value="$ALBName" --unit Count --period 300 --evaluation-periods 1 --threshold 0 --comparison-operator GreaterThanThreshold --alarm-actions \'"$ALARMACTION"\' --output=json --profile $profile --region $Region 2>&1
+				echo aws cloudwatch put-metric-alarm --alarm-name "$ALBName - ALB Unhealthy Hosts" --metric-name UnHealthyHostCount --namespace AWS/ApplicationELB --statistic Maximum --dimensions Name=LoadBalancerName,Value="$ALBName" --unit Count --period 300 --evaluation-periods 1 --threshold 0 --comparison-operator GreaterThanThreshold --alarm-actions \'"$ALARMACTION"\' --output=json --region $Region 2>&1
 			fi
-			SetAlarm=$(aws cloudwatch put-metric-alarm --alarm-name "$ALBName - ALB Unhealthy Hosts" --metric-name UnHealthyHostCount --namespace AWS/ApplicationELB --statistic Maximum --dimensions Name=LoadBalancerName,Value="$ALBName" --unit Count --period 300 --evaluation-periods 1 --threshold 0 --comparison-operator GreaterThanThreshold --alarm-actions "$ALARMACTION" --output=json --profile $profile --region $Region 2>&1)
+			SetAlarm=$(aws cloudwatch put-metric-alarm --alarm-name "$ALBName - ALB Unhealthy Hosts" --metric-name UnHealthyHostCount --namespace AWS/ApplicationELB --statistic Maximum --dimensions Name=LoadBalancerName,Value="$ALBName" --unit Count --period 300 --evaluation-periods 1 --threshold 0 --comparison-operator GreaterThanThreshold --alarm-actions "$ALARMACTION" --output=json --region $Region 2>&1)
 			if [ ! $? -eq 0 ]; then
 				fail "$SetAlarm"
 			fi
-			VerifyAlarm=$(aws cloudwatch describe-alarms --alarm-names "$ALBName - ALB Unhealthy Hosts" --output=json --profile $profile --region $Region 2>&1)
+			VerifyAlarm=$(aws cloudwatch describe-alarms --alarm-names "$ALBName - ALB Unhealthy Hosts" --output=json --region $Region 2>&1)
 			if [ ! $? -eq 0 ]; then
 				fail "$VerifyAlarm"
 			fi

--- a/cloudwatch-create-alarms.sh
+++ b/cloudwatch-create-alarms.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
 # This script creates AWS CloudWatch alarms based on standard metrics and user input to setup alarms for each environment
 # Requires AWS CLI Setup and you must setup your ALARMACTION
 
@@ -85,12 +92,12 @@ if [[ $SERVERNUM > 0 ]] && echo "$SERVERNUM" | egrep -q '^[0-9]+$'; then
     fi
 
     # Load Balancer Unhealthy Host Check
-    aws cloudwatch put-metric-alarm --alarm-name "$CLIENT Unhealthy Host Check" --alarm-description "$CLIENT Load Balancer Unhealthy Host Detected" --metric-name "UnHealthyHostCount" --namespace "AWS/ELB" --statistic "Sum" --period 60 --threshold 0 --comparison-operator "GreaterThanThreshold" --dimensions Name=LoadBalancerName,Value=$LBID --evaluation-periods 3 --alarm-actions "$ALARMACTION" --profile $profile
+    aws cloudwatch put-metric-alarm --alarm-name "$CLIENT Unhealthy Host Check" --alarm-description "$CLIENT Load Balancer Unhealthy Host Detected" --metric-name "UnHealthyHostCount" --namespace "AWS/ELB" --statistic "Sum" --period 60 --threshold 0 --comparison-operator "GreaterThanThreshold" --dimensions Name=LoadBalancerName,Value=$LBID --evaluation-periods 3 --alarm-actions "$ALARMACTION"
     HorizontalRule
     echo "Load Balancer Unhealthy Host Alarm Set"
     HorizontalRule
     # Load Balancer High Latency Check
-    aws cloudwatch put-metric-alarm --alarm-name "$CLIENT LB High Latency" --alarm-description "$CLIENT Load Balancer High Latency" --metric-name "Latency" --namespace "AWS/ELB" --statistic "Average" --period 60 --threshold 15 --comparison-operator "GreaterThanThreshold" --dimensions Name=LoadBalancerName,Value=$LBID --evaluation-periods 2 --alarm-actions "$ALARMACTION" --profile $profile
+    aws cloudwatch put-metric-alarm --alarm-name "$CLIENT LB High Latency" --alarm-description "$CLIENT Load Balancer High Latency" --metric-name "Latency" --namespace "AWS/ELB" --statistic "Average" --period 60 --threshold 15 --comparison-operator "GreaterThanThreshold" --dimensions Name=LoadBalancerName,Value=$LBID --evaluation-periods 2 --alarm-actions "$ALARMACTION"
     HorizontalRule
     echo "Load Balancer High Latency Alarm Set"
     HorizontalRule
@@ -113,13 +120,13 @@ if [[ $SERVERNUM > 0 ]] && echo "$SERVERNUM" | egrep -q '^[0-9]+$'; then
     if [[ "$INSTANCEID" =~ ^([i]-........)|([i]-.................)$ ]]; then
 
         # CPU Check
-        aws cloudwatch put-metric-alarm --alarm-name "$CLIENT $ENVIRONMENT $SERVERNAME CPU Check" --alarm-description "$CLIENT $ENVIRONMENT $SERVERNAME CPU usage >90% for 5 minutes" --namespace "AWS/EC2" --dimensions Name=InstanceId,Value=$INSTANCEID --metric-name "CPUUtilization" --statistic "Average" --comparison-operator "GreaterThanThreshold" --unit "Percent" --period 60 --threshold 90 --evaluation-periods 5 --alarm-actions "$ALARMACTION" --profile $profile
+        aws cloudwatch put-metric-alarm --alarm-name "$CLIENT $ENVIRONMENT $SERVERNAME CPU Check" --alarm-description "$CLIENT $ENVIRONMENT $SERVERNAME CPU usage >90% for 5 minutes" --namespace "AWS/EC2" --dimensions Name=InstanceId,Value=$INSTANCEID --metric-name "CPUUtilization" --statistic "Average" --comparison-operator "GreaterThanThreshold" --unit "Percent" --period 60 --threshold 90 --evaluation-periods 5 --alarm-actions "$ALARMACTION"
         HorizontalRule
         echo $CLIENT $ENVIRONMENT $SERVERNAME "CPU Check Alarm Set"
         HorizontalRule
 
         # Status Check
-        aws cloudwatch put-metric-alarm --alarm-name "$CLIENT $ENVIRONMENT $SERVERNAME Status Check" --alarm-description "$CLIENT $ENVIRONMENT $SERVERNAME Status Check Failed for 5 minutes" --namespace "AWS/EC2" --dimensions Name=InstanceId,Value=$INSTANCEID --metric-name "StatusCheckFailed" --statistic "Maximum" --comparison-operator "GreaterThanThreshold" --unit "Count" --period 60 --threshold 0 --evaluation-periods 5 --alarm-actions "$ALARMACTION" --profile $profile
+        aws cloudwatch put-metric-alarm --alarm-name "$CLIENT $ENVIRONMENT $SERVERNAME Status Check" --alarm-description "$CLIENT $ENVIRONMENT $SERVERNAME Status Check Failed for 5 minutes" --namespace "AWS/EC2" --dimensions Name=InstanceId,Value=$INSTANCEID --metric-name "StatusCheckFailed" --statistic "Maximum" --comparison-operator "GreaterThanThreshold" --unit "Count" --period 60 --threshold 0 --evaluation-periods 5 --alarm-actions "$ALARMACTION"
         HorizontalRule
         echo $CLIENT $ENVIRONMENT $SERVERNAME "Status Check Alarm Set"
         HorizontalRule
@@ -163,19 +170,19 @@ read -r -p "Setup Database Alarms? (y/n) " SETUPDB
         fi
 
         # Database CPU Check
-        aws cloudwatch put-metric-alarm --alarm-name "$CLIENT $ENVIRONMENT DB CPU Check" --alarm-description "$CLIENT $ENVIRONMENT Database CPU usage >90% for 5 minutes" --metric-name "CPUUtilization" --namespace "AWS/RDS" --statistic "Average" --unit "Percent" --period 60 --threshold 90 --comparison-operator "GreaterThanThreshold" --dimensions Name=DBInstanceIdentifier,Value=$DBID --evaluation-periods 5 --alarm-actions "$ALARMACTION" --profile $profile
+        aws cloudwatch put-metric-alarm --alarm-name "$CLIENT $ENVIRONMENT DB CPU Check" --alarm-description "$CLIENT $ENVIRONMENT Database CPU usage >90% for 5 minutes" --metric-name "CPUUtilization" --namespace "AWS/RDS" --statistic "Average" --unit "Percent" --period 60 --threshold 90 --comparison-operator "GreaterThanThreshold" --dimensions Name=DBInstanceIdentifier,Value=$DBID --evaluation-periods 5 --alarm-actions "$ALARMACTION"
         HorizontalRule
         echo $CLIENT $ENVIRONMENT "Database CPU Check Alarm Set"
         HorizontalRule
 
         # Database Memory Usage Check
-        aws cloudwatch put-metric-alarm --alarm-name "$CLIENT $ENVIRONMENT DB Mem Check" --alarm-description "$CLIENT $ENVIRONMENT Database Freeable Memory < 200 MB for 5 minutes" --metric-name "FreeableMemory" --namespace "AWS/RDS" --statistic "Average" --unit "Bytes" --period 60 --threshold "200000000" --comparison-operator "LessThanThreshold" --dimensions Name=DBInstanceIdentifier,Value=$DBID --evaluation-periods 5 --alarm-actions "$ALARMACTION" --profile $profile
+        aws cloudwatch put-metric-alarm --alarm-name "$CLIENT $ENVIRONMENT DB Mem Check" --alarm-description "$CLIENT $ENVIRONMENT Database Freeable Memory < 200 MB for 5 minutes" --metric-name "FreeableMemory" --namespace "AWS/RDS" --statistic "Average" --unit "Bytes" --period 60 --threshold "200000000" --comparison-operator "LessThanThreshold" --dimensions Name=DBInstanceIdentifier,Value=$DBID --evaluation-periods 5 --alarm-actions "$ALARMACTION"
         HorizontalRule
         echo $CLIENT $ENVIRONMENT "Database Memory Usage Alarm Set"
         HorizontalRule
 
         # Database Available Storage Space Check
-        aws cloudwatch put-metric-alarm --alarm-name "$CLIENT $ENVIRONMENT DB Storage Check" --alarm-description "$CLIENT $ENVIRONMENT Database Available Storage Space < 200 MB" --metric-name "FreeStorageSpace" --namespace "AWS/RDS" --statistic "Average" --unit "Bytes" --period 60 --threshold "200000000" --comparison-operator "LessThanThreshold" --dimensions Name=DBInstanceIdentifier,Value=$DBID --evaluation-periods 1 --alarm-actions "$ALARMACTION" --profile $profile
+        aws cloudwatch put-metric-alarm --alarm-name "$CLIENT $ENVIRONMENT DB Storage Check" --alarm-description "$CLIENT $ENVIRONMENT Database Available Storage Space < 200 MB" --metric-name "FreeStorageSpace" --namespace "AWS/RDS" --statistic "Average" --unit "Bytes" --period 60 --threshold "200000000" --comparison-operator "LessThanThreshold" --dimensions Name=DBInstanceIdentifier,Value=$DBID --evaluation-periods 1 --alarm-actions "$ALARMACTION"
         HorizontalRule
         echo $CLIENT $ENVIRONMENT "Database Available Storage Space Alarm Set"
         HorizontalRule

--- a/cloudwatch-logs-cleanup.sh
+++ b/cloudwatch-logs-cleanup.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will delete all CloudWatch Log Groups with a Last Event that is older than the Retention Policy in all regions available
 # Requires the AWS CLI and jq
 
@@ -105,7 +112,7 @@ function GetRegions(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin GetRegions Function"
 	fi
-	AWSregions=$(aws ec2 describe-regions --output=json --profile $profile 2>&1)
+	AWSregions=$(aws ec2 describe-regions --output=json 2>&1)
 	if echo "$AWSregions" | egrep -iq "error|not"; then
 		fail "$AWSregions"
 	else
@@ -145,7 +152,7 @@ function ListLogGroups(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin ListLogGroups Function"
 	fi
-	ListLogGroups=$(aws logs describe-log-groups --region=$Region --output=json --profile $profile 2>&1)
+	ListLogGroups=$(aws logs describe-log-groups --region=$Region --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$ListLogGroups"
 	# if echo "$ListLogGroups" | egrep -iq "error|not"; then
@@ -187,7 +194,7 @@ function CheckRetentionPolicy(){
 			echo "o0o0o0o"
 			pause
 		fi
-		CheckRetentionPolicy=$(aws logs describe-log-groups --region $Region --log-group-name-prefix $LogGroup --output=json --profile $profile 2>&1)
+		CheckRetentionPolicy=$(aws logs describe-log-groups --region $Region --log-group-name-prefix $LogGroup --output=json 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$CheckRetentionPolicy"
 		fi
@@ -223,7 +230,7 @@ function CheckLogStream(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin CheckLogStream Function"
 	fi
-	CheckLogStream=$(aws logs describe-log-streams --region $Region --log-group-name $LogGroup --max-items 1 --order-by LastEventTime --descending --output=json --profile $profile 2>&1)
+	CheckLogStream=$(aws logs describe-log-streams --region $Region --log-group-name $LogGroup --max-items 1 --order-by LastEventTime --descending --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$CheckLogStream"
 	fi
@@ -313,7 +320,7 @@ function CheckTimestamp(){
 # Delete Log Group
 function DeleteLogGroup(){
 	echo "Deleting Log Group..."
-	DeleteLogGroup=$(aws logs delete-log-group --region $Region --log-group-name $LogGroup --output=json --profile $profile 2>&1)
+	DeleteLogGroup=$(aws logs delete-log-group --region $Region --log-group-name $LogGroup --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$DeleteLogGroup"
 	fi

--- a/cloudwatch-logs-delete-groups.sh
+++ b/cloudwatch-logs-delete-groups.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will quickly delete all CloudWatch Log Groups with a specified prefix in all regions available
 # Requires the AWS CLI and jq
 
@@ -115,7 +122,7 @@ function GetRegions(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin GetRegions Function"
 	fi
-	AWSregions=$(aws ec2 describe-regions --output=json --profile $profile 2>&1)
+	AWSregions=$(aws ec2 describe-regions --output=json 2>&1)
 	if echo "$AWSregions" | egrep -iq "error|not"; then
 		fail "$AWSregions"
 	else
@@ -155,7 +162,7 @@ function ListLogGroups(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin ListLogGroups Function"
 	fi
-	ListLogGroups=$(aws logs describe-log-groups --log-group-name-prefix "$Prefix" --region=$Region --output=json --profile $profile 2>&1)
+	ListLogGroups=$(aws logs describe-log-groups --log-group-name-prefix "$Prefix" --region=$Region --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$ListLogGroups"
 	# if echo "$ListLogGroups" | egrep -iq "error|not"; then
@@ -201,7 +208,7 @@ function DeleteLogGroup(){
 			pause
 		fi
 		echo "Deleting Log Group: $LogGroup"
-		DeleteLogGroup=$(aws logs delete-log-group --region $Region --log-group-name $LogGroup --output=json --profile $profile 2>&1)
+		DeleteLogGroup=$(aws logs delete-log-group --region $Region --log-group-name $LogGroup --output=json 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$DeleteLogGroup"
 		fi

--- a/cloudwatch-logs-retention-policy.sh
+++ b/cloudwatch-logs-retention-policy.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will set CloudWatch Logs Retention Policy to x number of days for all log groups in all regions available
 # Requires the AWS CLI and jq
 
@@ -92,7 +99,7 @@ function GetRegions(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin GetRegions Function"
 	fi
-	AWSregions=$(aws ec2 describe-regions --output=json --profile $profile 2>&1)
+	AWSregions=$(aws ec2 describe-regions --output=json 2>&1)
 	if echo "$AWSregions" | egrep -iq "error"; then
 		fail "$AWSregions"
 	else
@@ -132,7 +139,7 @@ function ListLogGroups(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin ListLogGroups Function"
 	fi
-	ListLogGroups=$(aws logs describe-log-groups --region=$Region --output=json --profile $profile 2>&1)
+	ListLogGroups=$(aws logs describe-log-groups --region=$Region --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$ListLogGroups"
 	# if echo "$ListLogGroups" | egrep -iq "error|not"; then
@@ -175,7 +182,7 @@ function SetRetentionPolicy(){
 			echo "o0o0o0o"
 			pause
 		fi
-		SetRetentionPolicy=$(aws logs put-retention-policy --region $Region --log-group-name $LogGroup --retention-in-days $RetentionInDays --output=json --profile $profile 2>&1)
+		SetRetentionPolicy=$(aws logs put-retention-policy --region $Region --log-group-name $LogGroup --retention-in-days $RetentionInDays --output=json 2>&1)
 		if echo "$SetRetentionPolicy" | egrep -iq "error|not"; then
 			fail "$SetRetentionPolicy"
 		fi

--- a/cloudwatch-logs-search.sh
+++ b/cloudwatch-logs-search.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will search all CloudWatch Logs (all log groups in all regions available) for a filter string
 # Requires the AWS CLI and jq
 
@@ -102,7 +109,7 @@ function GetRegions(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin GetRegions Function"
 	fi
-	AWSregions=$(aws ec2 describe-regions --output=json --profile $profile 2>&1)
+	AWSregions=$(aws ec2 describe-regions --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$AWSregions"
 	else
@@ -144,7 +151,7 @@ function ListLogGroups(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "Begin ListLogGroups Function"
 	fi
-	ListLogGroups=$(aws logs describe-log-groups --region=$Region --output=json --profile $profile 2>&1)
+	ListLogGroups=$(aws logs describe-log-groups --region=$Region --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$ListLogGroups"
 	else
@@ -191,7 +198,7 @@ function FilterLogEvents(){
 			if [[ $DEBUGMODE = "1" ]]; then
 				echo "Searching Single Log Group: $LogGroupName"
 			fi
-			FilterLogEvents=$(aws logs filter-log-events --region $Region --log-group-name "$LogGroupName" --filter-pattern \""$FilterPattern"\" --output=json --profile $profile 2>&1)
+			FilterLogEvents=$(aws logs filter-log-events --region $Region --log-group-name "$LogGroupName" --filter-pattern \""$FilterPattern"\" --output=json 2>&1)
 			if [ ! $? -eq 0 ]; then
 				fail "$FilterLogEvents"
 			fi
@@ -219,7 +226,7 @@ function FilterLogEvents(){
 				echo "LogGroup: $LogGroup"
 				pause
 			fi
-			FilterLogEvents=$(aws logs filter-log-events --region $Region --log-group-name "$LogGroup" --filter-pattern \""$FilterPattern"\" --output=json --profile $profile 2>&1)
+			FilterLogEvents=$(aws logs filter-log-events --region $Region --log-group-name "$LogGroup" --filter-pattern \""$FilterPattern"\" --output=json 2>&1)
 			if [ ! $? -eq 0 ]; then
 				fail "$FilterLogEvents"
 			fi

--- a/ec2-ami-encrypted-ebs-boot-volume.sh
+++ b/ec2-ami-encrypted-ebs-boot-volume.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will create an AMI with an encrypted boot volume from the latest Amazon Linux AMI (amzn-ami-hvm-x86_64-gp2)
 
 # See:
@@ -97,7 +104,7 @@ function ClientToken(){
 # Determine region
 function GetRegion(){
 	if [ "$Region" == "default" ]; then
-		Region=$(aws configure get region --profile $profile 2>&1)
+		Region=$(aws configure get region 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$Region"
 		fi
@@ -109,7 +116,7 @@ function GetRegion(){
 
 # Get the latest Amazon Linux AMI ID
 function GetAMI(){
-	AMI=$(aws ssm get-parameters --names /aws/service/ami-amazon-linux-latest/"$AMITYPE" --region $Region --profile $profile 2>&1)
+	AMI=$(aws ssm get-parameters --names /aws/service/ami-amazon-linux-latest/"$AMITYPE" --region $Region 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$AMI"
 	fi
@@ -130,7 +137,7 @@ function GetAMI(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "AMIID: $AMIID"
 	fi
-	DESCR=$(aws ec2 describe-images --image-ids "$AMIID" --region $Region --profile $profile 2>&1)
+	DESCR=$(aws ec2 describe-images --image-ids "$AMIID" --region $Region 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$DESCR"
 	fi
@@ -149,7 +156,7 @@ function GetAMI(){
 
 # Build encrypted AMI
 function EncryptAMI(){
-	Encrypt=$(aws ec2 copy-image --encrypted --client-token "$ClientToken" --description "Encrypted $DESCR ($AMIID)" --name "Encrypted $DESCR ($AMIID)" --source-image-id "$AMIID" --source-region $Region --region $Region --profile $profile 2>&1)
+	Encrypt=$(aws ec2 copy-image --encrypted --client-token "$ClientToken" --description "Encrypted $DESCR ($AMIID)" --name "Encrypted $DESCR ($AMIID)" --source-image-id "$AMIID" --source-region $Region --region $Region 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$Encrypt"
 	fi
@@ -175,7 +182,7 @@ function TagAMI(){
 	echo
 	echo
 	echo "Creating Name Tag for AMI ID: $EncryptedAMI"
-	Tag=$(aws ec2 create-tags --resources "$EncryptedAMI" --tags "Key=Name,Value=Encrypted $DESCR ($AMIID)" --region $Region --profile $profile 2>&1)
+	Tag=$(aws ec2 create-tags --resources "$EncryptedAMI" --tags "Key=Name,Value=Encrypted $DESCR ($AMIID)" --region $Region 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$Tag"
 	fi
@@ -183,7 +190,7 @@ function TagAMI(){
 
 # Tag the Snapshot
 function QuicklyTagSnapshot(){
-	CallerID=$(aws sts get-caller-identity --profile $profile 2>&1)
+	CallerID=$(aws sts get-caller-identity 2>&1)
 	# if [ ! $? -eq 0 ]; then
 	# 	error "$CallerID"
 	# fi
@@ -194,7 +201,7 @@ function QuicklyTagSnapshot(){
 	if [[ $DEBUGMODE = "1" ]]; then
 		echo "AccountID: $AccountID"
 	fi
-	Snapshots=$(aws ec2 describe-snapshots --owner-ids $AccountID --filters Name=status,Values=pending --region $Region --profile $profile 2>&1)
+	Snapshots=$(aws ec2 describe-snapshots --owner-ids $AccountID --filters Name=status,Values=pending --region $Region 2>&1)
 	if [ ! $? -eq 0 ]; then
 		error "$Snapshots"
 	fi
@@ -219,7 +226,7 @@ function QuicklyTagSnapshot(){
 		fi
 		echo
 		echo "Creating Name Tag for Snapshot ID: $SnapshotID"
-		SnapshotTag=$(aws ec2 create-tags --resources "$SnapshotID" --tags "Key=Name,Value=Encrypted $DESCR ($AMIID)" --region $Region --profile $profile 2>&1)
+		SnapshotTag=$(aws ec2 create-tags --resources "$SnapshotID" --tags "Key=Name,Value=Encrypted $DESCR ($AMIID)" --region $Region 2>&1)
 		if [ ! $? -eq 0 ]; then
 			error "$SnapshotTag"
 		fi
@@ -252,7 +259,7 @@ function SlowlyTagSnapshot(){
 	if [ -z "$SnapshotID" ]; then
 		fail "Unable to get Snapshot ID or Tag Snapshot."
 	fi
-	SnapshotTag=$(aws ec2 create-tags --resources "$SnapshotID" --tags "Key=Name,Value=Encrypted $DESCR ($AMIID)" --region $Region --profile $profile 2>&1)
+	SnapshotTag=$(aws ec2 create-tags --resources "$SnapshotID" --tags "Key=Name,Value=Encrypted $DESCR ($AMIID)" --region $Region 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$SnapshotTag"
 	fi
@@ -262,7 +269,7 @@ function SlowlyTagSnapshot(){
 
 # Check AMI State
 function CheckState(){
-	AMIdescr=$(aws ec2 describe-images --image-ids "$EncryptedAMI" --region $Region --profile $profile 2>&1)
+	AMIdescr=$(aws ec2 describe-images --image-ids "$EncryptedAMI" --region $Region 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$AMIdescr"
 	fi

--- a/ec2-elb-export-template.sh
+++ b/ec2-elb-export-template.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will export an AWS ELB to a JSON Template File for version control
 # The ELB can then be duplicated or renamed or recreated from the JSON Template File
 # An AWS CLI profile can be passed into the script as an argument
@@ -118,7 +125,7 @@ if [ "$CreateTemplateFile" = "true" ]; then
 
 
 
-	DescribeLB=$(aws elb describe-load-balancers --load-balancer-names $ELBname --profile $profile 2>&1)
+	DescribeLB=$(aws elb describe-load-balancers --load-balancer-names $ELBname 2>&1)
 	if echo $DescribeLB | grep -q "could not be found"; then
 		fail "$DescribeLB"
 	fi
@@ -133,7 +140,7 @@ if [ "$CreateTemplateFile" = "true" ]; then
 		echo "$DescribeLB" > "$TemplateFileName"1
 	fi
 
-	DescribeAttributes=$(aws elb describe-load-balancer-attributes --load-balancer-name $ELBname --profile $profile 2>&1)
+	DescribeAttributes=$(aws elb describe-load-balancer-attributes --load-balancer-name $ELBname 2>&1)
 	if echo $DescribeAttributes | grep -q "error"; then
 		fail "$DescribeAttributes"
 	else
@@ -161,7 +168,7 @@ if [ "$CreateNewELB" = "true" ]; then
 	fi
 
 	# Check for an existing ELB with the same name as the new ELB
-	TestNewELB=$(aws elb describe-load-balancers --load-balancer-names $NewELBname --profile $profile 2>&1)
+	TestNewELB=$(aws elb describe-load-balancers --load-balancer-names $NewELBname 2>&1)
 	if echo "$TestNewELB" | grep -q "An error occurred"; then
 		echo
 	else
@@ -375,7 +382,7 @@ if [ "$CreateNewELB" = "true" ]; then
 	fi
 
 	# Create new ELB from JSON
-	CreateLoadBalancer=$(aws elb create-load-balancer --cli-input-json "$json" --profile $profile 2>&1)
+	CreateLoadBalancer=$(aws elb create-load-balancer --cli-input-json "$json" 2>&1)
 	if ! echo "$CreateLoadBalancer" | grep -qw "DNSName"; then
 		fail "$CreateLoadBalancer"
 	else
@@ -400,7 +407,7 @@ if [ "$CreateNewELB" = "true" ]; then
 		# json1=$(cat output1.json)
 
 		# Register Instances with ELB
-		RegisterInstances=$(aws elb register-instances-with-load-balancer --cli-input-json "$json1" --profile $profile 2>&1)
+		RegisterInstances=$(aws elb register-instances-with-load-balancer --cli-input-json "$json1" 2>&1)
 		if ! echo "$RegisterInstances" | grep -qw "Instances"; then
 			fail "$RegisterInstances"
 		else
@@ -447,7 +454,7 @@ if [ "$CreateNewELB" = "true" ]; then
 
 
 		# Configure Healthcheck from JSON
-		ConfigureHealthCheck=$(aws elb configure-health-check --cli-input-json "$json2" --profile $profile 2>&1)
+		ConfigureHealthCheck=$(aws elb configure-health-check --cli-input-json "$json2" 2>&1)
 		if ! echo "$ConfigureHealthCheck" | grep -qw "HealthCheck"; then
 			fail "$ConfigureHealthCheck"
 		else
@@ -502,7 +509,7 @@ if [ "$CreateNewELB" = "true" ]; then
 
 
 		# Configure Attributes from JSON
-		ConfigureAttributes=$(aws elb modify-load-balancer-attributes --cli-input-json "$json3" --profile $profile 2>&1)
+		ConfigureAttributes=$(aws elb modify-load-balancer-attributes --cli-input-json "$json3" 2>&1)
 		if ! echo "$ConfigureAttributes" | grep -qw "LoadBalancerAttributes"; then
 			fail "$ConfigureAttributes"
 		else

--- a/ec2-elb-upload-ssl-cert.sh
+++ b/ec2-elb-upload-ssl-cert.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
 # This script will upload an SSL Certificate to AWS for use in setting up an ELB
 # Requires AWS CLI Setup and jq
 
@@ -73,7 +80,7 @@ function import(){
 	if [ -z "$profile" ]; then
 		IMPORT=$(aws iam upload-server-certificate --server-certificate-name "$DOMAIN" --certificate-body "$PUBKEY" --private-key "$PRIVATE" --certificate-chain "$CHAIN" 2>&1)
 	else
-		IMPORT=$(aws iam upload-server-certificate --profile $profile --server-certificate-name "$DOMAIN" --certificate-body "$PUBKEY" --private-key "$PRIVATE" --certificate-chain "$CHAIN" 2>&1)
+		IMPORT=$(aws iam upload-server-certificate --server-certificate-name "$DOMAIN" --certificate-body "$PUBKEY" --private-key "$PRIVATE" --certificate-chain "$CHAIN" 2>&1)
 	fi
 	# aws iam upload-server-certificate --server-certificate-name "$DOMAIN" --certificate-body file://"$PUBKEY" --private-key file://"$PRIVATE" --certificate-chain file://"$CHAIN"
 	# aws iam upload-server-certificate --server-certificate-name $DOMAIN-$EXPDATE --certificate-body file://$PUBKEY --private-key file://$PRIVATE --certificate-chain file://$CHAIN

--- a/elastic-beanstalk-update-hostnames.sh
+++ b/elastic-beanstalk-update-hostnames.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script updates the hostname on Elastic Beanstalk servers with their environment name and IP address
 # It also will restart New Relic monitoring if present
 # Requires the AWS CLI and jq
@@ -71,7 +78,7 @@ check_command "jq"
 
 # Get Elastic Beanstalk Environments
 function ebenvironments(){
-	describeenvironments=$(aws elasticbeanstalk describe-environments --output=json --profile $profile 2>&1)
+	describeenvironments=$(aws elasticbeanstalk describe-environments --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$describeenvironments"
 	fi
@@ -89,7 +96,7 @@ function ebenvironments(){
 function ebresources(){
 	while IFS= read -r ebenvironments
 	do
-		describeebresources=$(aws elasticbeanstalk describe-environment-resources --environment-name $ebenvironments --output=json --profile $profile 2>&1)
+		describeebresources=$(aws elasticbeanstalk describe-environment-resources --environment-name $ebenvironments --output=json 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$describeebresources"
 		fi
@@ -121,7 +128,7 @@ function ebresources(){
 			if [[ $DEBUGMODE = "1" ]]; then
 				echo "Getting IP for Instance ID: $currentinstanceid"
 			fi
-			describeinstances=$(aws ec2 describe-instances --instance-ids "$currentinstanceid" --query 'Reservations[*].Instances[*].PublicIpAddress' --output=json --profile $profile 2>&1)
+			describeinstances=$(aws ec2 describe-instances --instance-ids "$currentinstanceid" --query 'Reservations[*].Instances[*].PublicIpAddress' --output=json 2>&1)
 			if [ ! $? -eq 0 ]; then
 				fail "$describeinstances"
 			fi

--- a/route53-export-zones.sh
+++ b/route53-export-zones.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
 # This script will use cli53 to export the zone file for each Hosted Zone domain in Route 53 for git version control
 # Requires Python, pip, awscli, cli53
 # For more info on cli53 see https://github.com/barnybug/cli53
@@ -89,7 +96,7 @@ check_command "cli53"
 # fi
 
 # Get list of Hosted Zones in Route 53
-DOMAINLIST=$(aws route53 list-hosted-zones --output text --profile $profile | cut -f 4 | rev | cut -c 2- | rev | grep -v '^$')
+DOMAINLIST=$(aws route53 list-hosted-zones --output text | cut -f 4 | rev | cut -c 2- | rev | grep -v '^$')
 
 if [ -z "$DOMAINLIST" ]; then
 	fail "No hosted zones found in Route 53!"
@@ -118,7 +125,7 @@ do
 	HorizontalRule
 	echo \#$COUNT
 	DOMAIN_ID=$(echo "$DOMAINLIST" | nl | grep -w $COUNT | cut -f 2)
-	cli53 export --full --profile $profile $DOMAIN_ID > route53zones/$profile/$DOMAIN_ID.zone
+	cli53 export --full $DOMAIN_ID > route53zones/$profile/$DOMAIN_ID.zone
 	echo "Exported: "$DOMAIN_ID
 done
 

--- a/route53-record-set.sh
+++ b/route53-record-set.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 HOSTEDZONEID="id"
-profile="xyz"
 
 cat > change-batch.json << EOL
 {"Comment":"test","Changes":[{"Action":"CREATE","ResourceRecordSet":{"Name":"mail.shawnwoodford.com","Type":"CNAME","Region":"us-east-1","TTL":300,"ResourceRecords":[{"Value":"ghs.googlehosted.com"}]}}]}
 EOL
 
-# aws route53 change-resource-record-sets --hosted-zone-id $HOSTEDZONEID --profile $profile --cli-input-json '
+# aws route53 change-resource-record-sets --hosted-zone-id $HOSTEDZONEID --cli-input-json '
 # {
 #   "HostedZoneId": "$HOSTEDZONEID",
 #   "ChangeBatch": {
@@ -29,6 +35,6 @@ EOL
 
 # rm change-batch.json
 
-# aws route53 change-resource-record-sets --hosted-zone-id $HOSTEDZONEID --profile $profile --cli-input-json '{"HostedZoneId":"$HOSTEDZONEID","ChangeBatch":{"Comment":"test","Changes":[{"Action":"CREATE","ResourceRecordSet":{"Name":"mail.shawnwoodford.com","Type":"CNAME","Region":"us-east-1","TTL":300,"ResourceRecords":[{"Value":"ghs.googlehosted.com"}]}}]}}'
+# aws route53 change-resource-record-sets --hosted-zone-id $HOSTEDZONEID --cli-input-json '{"HostedZoneId":"$HOSTEDZONEID","ChangeBatch":{"Comment":"test","Changes":[{"Action":"CREATE","ResourceRecordSet":{"Name":"mail.shawnwoodford.com","Type":"CNAME","Region":"us-east-1","TTL":300,"ResourceRecords":[{"Value":"ghs.googlehosted.com"}]}}]}}'
 
-aws route53 change-resource-record-sets --hosted-zone-id $HOSTEDZONEID --profile $profile --change-batch file://change-batch.json
+aws route53 change-resource-record-sets --hosted-zone-id $HOSTEDZONEID --change-batch file://change-batch.json

--- a/s3-buckets-local-backup.sh
+++ b/s3-buckets-local-backup.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
 # Script to backup all S3 bucket contents locally
 # Contents of each S3 bucket will be copied to the local subfolder specified
 # Requires aws cli (AWS CLI profile must have IAM permission to access all buckets)
@@ -55,7 +62,7 @@ else
 fi
 
 # List buckets
-LS=$(aws s3 ls --profile $profile 2>&1)
+LS=$(aws s3 ls 2>&1)
 if [ ! $? -eq 0 ]; then
   fail "$LS"
 fi
@@ -90,7 +97,7 @@ do
   echo \#$COUNT $CURRENTBUCKET
 
   # Determine the bucket region
-  REGION=$(aws s3api get-bucket-location --bucket $CURRENTBUCKET --output text --profile $profile 2>&1)
+  REGION=$(aws s3api get-bucket-location --bucket $CURRENTBUCKET --output text 2>&1)
   if [ ! $? -eq 0 ]; then
     fail "$REGION"
   fi
@@ -99,7 +106,7 @@ do
   fi
 
   # Backup the S3 bucket contents
-  BACKUP=$(aws s3 sync s3://$CURRENTBUCKET $SUBFOLDER/$CURRENTBUCKET/ --region $REGION --profile $profile --quiet 2>&1)
+  BACKUP=$(aws s3 sync s3://$CURRENTBUCKET $SUBFOLDER/$CURRENTBUCKET/ --region $REGION --quiet 2>&1)
   if [ ! $? -eq 0 ]; then
     fail "$BACKUP"
   fi

--- a/s3-buckets-security-audit.sh
+++ b/s3-buckets-security-audit.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
 # Script to export S3 bucket ACL, CORS, Policy and Website JSON for auditing security of all buckets
 # Each S3 bucket will have a JSON file generated in the subfolder specified
 # Requires aws s3api, jq, (AWS CLI profile must have IAM permission to access all buckets)
@@ -59,7 +66,7 @@ else
 fi
 
 # List buckets
-LS=$(aws s3 ls --profile $profile 2>&1)
+LS=$(aws s3 ls 2>&1)
 
 if echo "$LS" | egrep -q "Error|error|not"; then
   fail "$LS"
@@ -113,7 +120,7 @@ do
   fi
 
   # Determine the bucket region
-  CURRENTBUCKETREGION=$(aws s3api get-bucket-location --bucket $CURRENTBUCKET --output text --profile $profile 2>&1)
+  CURRENTBUCKETREGION=$(aws s3api get-bucket-location --bucket $CURRENTBUCKET --output text 2>&1)
   if echo $CURRENTBUCKETREGION | grep -q "None"; then
     REGION="us-east-1"
   else
@@ -121,8 +128,8 @@ do
   fi
 
   # Lookup the access control policy
-  ACL=$(aws s3api get-bucket-acl --bucket $CURRENTBUCKET --region $REGION --profile $profile 2>&1)
-  # ACL=$(aws s3api get-bucket-acl --bucket $CURRENTBUCKET --profile $profile 2>&1 | sed 's/\,/;/g')
+  ACL=$(aws s3api get-bucket-acl --bucket $CURRENTBUCKET --region $REGION 2>&1)
+  # ACL=$(aws s3api get-bucket-acl --bucket $CURRENTBUCKET 2>&1 | sed 's/\,/;/g')
 
   if echo "$ACL" | grep -q "error"; then
     ACL='{
@@ -132,8 +139,8 @@ do
   fi
 
   # Lookup the CORS policy
-  CORS=$(aws s3api get-bucket-cors --bucket $CURRENTBUCKET --region $REGION --profile $profile 2>&1)
-  # CORS=$(aws s3api get-bucket-cors --bucket $CURRENTBUCKET --profile $profile 2>&1 | sed 's/\,/;/g')
+  CORS=$(aws s3api get-bucket-cors --bucket $CURRENTBUCKET --region $REGION 2>&1)
+  # CORS=$(aws s3api get-bucket-cors --bucket $CURRENTBUCKET 2>&1 | sed 's/\,/;/g')
 
   if echo "$CORS" | grep -q "error"; then
     CORS='{
@@ -143,7 +150,7 @@ do
   fi
 
   # Lookup the bucket policy
-  POLICY=$(aws s3api get-bucket-policy --bucket $CURRENTBUCKET --region $REGION --profile $profile --output text 2>&1)
+  POLICY=$(aws s3api get-bucket-policy --bucket $CURRENTBUCKET --region $REGION --output text 2>&1)
 
   if echo "$POLICY" | grep -q "error"; then
     POLICY='{
@@ -156,7 +163,7 @@ do
   fi
 
   # Lookup the website hosting policy
-  WEBSITE=$(aws s3api get-bucket-website --bucket $CURRENTBUCKET --region $REGION --profile $profile 2>&1)
+  WEBSITE=$(aws s3api get-bucket-website --bucket $CURRENTBUCKET --region $REGION 2>&1)
 
   if echo "$WEBSITE" | grep -q "error"; then
     WEBSITE='{

--- a/s3-buckets-total-file-size.sh
+++ b/s3-buckets-total-file-size.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
 # Script to count total size of all data stored in a single or in all S3 buckets
 # Requires aws s3api, jq, IAM account must have permission to access all buckets
 
@@ -96,13 +103,13 @@ function SingleBucket(){
   read -r -p "Bucket name: s3://" CURRENTBUCKET
   echo
   echo "Calculating size..."
-  CURRENTBUCKETREGION=$(aws s3api get-bucket-location --bucket $CURRENTBUCKET --output text --profile $profile 2>&1)
+  CURRENTBUCKETREGION=$(aws s3api get-bucket-location --bucket $CURRENTBUCKET --output text 2>&1)
   if echo $CURRENTBUCKETREGION | grep -q None; then
     REGION="us-east-1"
   else
     REGION=$CURRENTBUCKETREGION
   fi
-  CURRENTBUCKETSIZE=$(aws s3api list-objects --bucket $CURRENTBUCKET --region $REGION --output json --query "[sum(Contents[].Size)]" --profile $profile 2>&1)
+  CURRENTBUCKETSIZE=$(aws s3api list-objects --bucket $CURRENTBUCKET --region $REGION --output json --query "[sum(Contents[].Size)]" 2>&1)
   if echo $CURRENTBUCKETSIZE | grep -q invalid; then
     CURRENTBUCKETSIZE="0"
   else
@@ -116,7 +123,7 @@ function SingleBucket(){
 
 function AllBuckets(){
   # List buckets
-  LS=$(aws s3 ls --profile $profile 2>&1)
+  LS=$(aws s3 ls 2>&1)
 
   # Count number of buckets
   TOTALNUMBERS3BUCKETS=$(echo "$LS" | wc -l | rev | cut -d " " -f1 | rev)
@@ -140,13 +147,13 @@ function AllBuckets(){
     HorizontalRule
     echo \#$COUNT $CURRENTBUCKET
 
-    CURRENTBUCKETREGION=$(aws s3api get-bucket-location --bucket $CURRENTBUCKET --output text --profile $profile 2>&1)
+    CURRENTBUCKETREGION=$(aws s3api get-bucket-location --bucket $CURRENTBUCKET --output text 2>&1)
     if echo $CURRENTBUCKETREGION | grep -q None; then
       REGION="us-east-1"
     else
       REGION=$CURRENTBUCKETREGION
     fi
-    CURRENTBUCKETSIZE=$(aws s3api list-objects --bucket $CURRENTBUCKET --region $REGION --output json --query "[sum(Contents[].Size)]" --profile $profile 2>&1)
+    CURRENTBUCKETSIZE=$(aws s3api list-objects --bucket $CURRENTBUCKET --region $REGION --output json --query "[sum(Contents[].Size)]" 2>&1)
     if echo $CURRENTBUCKETSIZE | grep -q invalid; then
       CURRENTBUCKETSIZE="0"
     else

--- a/s3-fix-content-type-metadata.sh
+++ b/s3-fix-content-type-metadata.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # Safely fix invalid content-type metadata on AWS S3 bucket website assets for some common filetypes
 # Inclues CSS, JS, JSON, JPG, JPEG, GIF, PNG, SVG, PDF, XML
 
@@ -78,7 +85,7 @@ if [ "$BUCKET" = "YOUR-S3-BUCKET-NAME" ]; then
 fi
 
 # Determine the bucket region
-REGION=$(aws s3api get-bucket-location --bucket $BUCKET --output text --profile $profile 2>&1)
+REGION=$(aws s3api get-bucket-location --bucket $BUCKET --output text 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$REGION"
 fi
@@ -87,7 +94,7 @@ if echo $REGION | grep -q "None"; then
 fi
 
 message CSS
-css=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.css" --content-type "text/css" --metadata-directive "REPLACE" 2>&1)
+css=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.css" --content-type "text/css" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$css"
 fi
@@ -98,7 +105,7 @@ else
 fi
 
 message JS
-js=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.js" --content-type "application/javascript" --metadata-directive "REPLACE" 2>&1)
+js=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.js" --content-type "application/javascript" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$js"
 fi
@@ -109,7 +116,7 @@ else
 fi
 
 message JSON
-json=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.json" --content-type "application/json" --metadata-directive "REPLACE" 2>&1)
+json=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.json" --content-type "application/json" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$json"
 fi
@@ -120,7 +127,7 @@ else
 fi
 
 message JPG
-jpg=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.jpg" --content-type "image/jpeg" --metadata-directive "REPLACE" 2>&1)
+jpg=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.jpg" --content-type "image/jpeg" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$jpg"
 fi
@@ -130,7 +137,7 @@ else
 	echo "$jpg"
 fi
 message JPEG
-jpeg=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.jpeg" --content-type "image/jpeg" --metadata-directive "REPLACE" 2>&1)
+jpeg=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.jpeg" --content-type "image/jpeg" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$jpeg"
 fi
@@ -141,7 +148,7 @@ else
 fi
 
 message GIF
-gif=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.gif" --content-type "image/gif" --metadata-directive "REPLACE" 2>&1)
+gif=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.gif" --content-type "image/gif" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$gif"
 fi
@@ -152,7 +159,7 @@ else
 fi
 
 message PNG
-png=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.png" --content-type "image/png" --metadata-directive "REPLACE" 2>&1)
+png=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.png" --content-type "image/png" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$png"
 fi
@@ -163,7 +170,7 @@ else
 fi
 
 message SVG
-svg=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.svg" --content-type "image/svg+xml" --metadata-directive "REPLACE" 2>&1)
+svg=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.svg" --content-type "image/svg+xml" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$svg"
 fi
@@ -174,7 +181,7 @@ else
 fi
 
 message PDF
-pdf=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.pdf" --content-type "application/pdf" --metadata-directive "REPLACE" 2>&1)
+pdf=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.pdf" --content-type "application/pdf" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$pdf"
 fi
@@ -185,7 +192,7 @@ else
 fi
 
 message XML
-xml=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.xml" --content-type "text/xml" --metadata-directive "REPLACE" 2>&1)
+xml=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --exclude "*" --include "*.xml" --content-type "text/xml" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$xml"
 fi

--- a/s3-open-bucket-policy.sh
+++ b/s3-open-bucket-policy.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script sets an S3 bucket policy to allow GetObject requests from any IP.
 # Requires the AWS CLI and jq
 
@@ -37,26 +44,39 @@ fi
 # Check for AWS CLI profile argument passed into the script
 # http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles
 scriptname=`basename "$0"`
-if [ $# -eq 0 ]; then
-	echo "Usage: ./$scriptname profile environment"
-	echo "Where profile is the AWS CLI profile name"
-	echo "And environment is the environment name (dev/staging/prod/all)"
-	echo
-	echo "Using default profile and no environment name"
-	echo
-	profile=default
-elif [ $# -eq 1 ]; then
-	echo "Usage: ./$scriptname profile environment"
-	echo "Where profile is the AWS CLI profile name"
-	echo "And environment is the environment name (dev/staging/prod/all)"
-	echo
-	echo "Using profile $1 and no environment name"
-	echo
-	profile=$1
+if [ $# -gt 2 ]; then
+	fail "Invalid arguments. Usage: ./$scriptname [--profile AWS_PROFILE_NAME] [legacy_profile] [environment]"
 elif [ $# -eq 2 ]; then
 	echo "Using profile $1 and environment $2"
 	profile=$1
 	s3bucketenv=$2
+elif [ $# -eq 1 ]; then
+	if [ -n "${AWS_SCRIPT_PROFILE:-}" ] && [ "${AWS_SCRIPT_PROFILE}" != "$1" ]; then
+		profile="${AWS_SCRIPT_PROFILE}"
+		s3bucketenv=$1
+		echo "Using profile ${AWS_SCRIPT_PROFILE} and environment $s3bucketenv"
+	else
+		echo "Usage: ./$scriptname [--profile AWS_PROFILE_NAME] [legacy_profile] [environment]"
+		echo "Where profile is the AWS CLI profile name"
+		echo "And environment is the environment name (dev/staging/prod/all)"
+		echo
+		echo "Using profile $1 and no environment name"
+		echo
+		profile=$1
+	fi
+else
+	echo "Usage: ./$scriptname [--profile AWS_PROFILE_NAME] [legacy_profile] [environment]"
+	echo "Where profile is the AWS CLI profile name"
+	echo "And environment is the environment name (dev/staging/prod/all)"
+	echo
+	if [ -n "${AWS_SCRIPT_PROFILE:-}" ]; then
+		echo "Using profile ${AWS_SCRIPT_PROFILE} and no environment name"
+		profile="${AWS_SCRIPT_PROFILE}"
+	else
+		echo "Using default profile and no environment name"
+		profile=default
+	fi
+	echo
 fi
 
 # Check required commands
@@ -80,7 +100,7 @@ function JSONizePolicy {
 
 # Set the S3 bucket policy
 function setS3Policy {
-	setS3Policy=$(aws s3api put-bucket-policy --bucket $s3bucketname --policy file://policy.json --output=json --profile $profile 2>&1)
+	setS3Policy=$(aws s3api put-bucket-policy --bucket $s3bucketname --policy file://policy.json --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$setS3Policy"
 	fi
@@ -88,7 +108,7 @@ function setS3Policy {
 
 # Validate the new policy
 function validateS3Policy {
-	bucketpolicy=$(aws s3api get-bucket-policy --bucket $s3bucketname --output=text --profile $profile 2>&1)
+	bucketpolicy=$(aws s3api get-bucket-policy --bucket $s3bucketname --output=text 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$bucketpolicy"
 	fi

--- a/s3-remove-glacier-objects.sh
+++ b/s3-remove-glacier-objects.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
 # Script to delete all Glacier storage type objects in a single S3 bucket
 # Requires aws s3api, jq
 
@@ -73,7 +80,7 @@ if ! [[ $Proceed =~ ^([yY][eE][sS]|[yY])$ ]]; then
 	fail "Canceled."
 fi
 
-S3BUCKETREGION=$(aws s3api get-bucket-location --bucket "$S3BUCKET" --output text --profile $profile 2>&1)
+S3BUCKETREGION=$(aws s3api get-bucket-location --bucket "$S3BUCKET" --output text 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$S3BUCKETREGION"
 else
@@ -84,7 +91,7 @@ else
 	fi
 fi
 
-LISTGLACIER=$(aws s3api list-objects-v2 --bucket "$S3BUCKET" --query "Contents[?StorageClass=='GLACIER'].Key" --output json --profile $profile --max-items 9999 --region $REGION 2>&1)
+LISTGLACIER=$(aws s3api list-objects-v2 --bucket "$S3BUCKET" --query "Contents[?StorageClass=='GLACIER'].Key" --output json --max-items 9999 --region $REGION 2>&1)
 
 if [ ! $? -eq 0 ]; then
 	fail "$LISTGLACIER"
@@ -97,7 +104,7 @@ fi
 
 while read glacier
 do
-	RM=$(aws s3 rm s3://"$S3BUCKET"/"$glacier" --profile $profile --region $REGION 2>&1)
+	RM=$(aws s3 rm s3://"$S3BUCKET"/"$glacier" --region $REGION 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$RM"
 	else

--- a/s3-set-cache-control-max-age.sh
+++ b/s3-set-cache-control-max-age.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # Set Cache-Control public with max-age value on AWS S3 bucket website assets for all filetypes
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 
@@ -89,7 +96,7 @@ if ! [ "$MAXAGE" -ge "0" ] || ! [ "$MAXAGE" -le "31536000" ]; then
 fi
 
 # Determine the bucket region
-REGION=$(aws s3api get-bucket-location --bucket $BUCKET --output text --profile $profile 2>&1)
+REGION=$(aws s3api get-bucket-location --bucket $BUCKET --output text 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$REGION"
 fi
@@ -98,7 +105,7 @@ if echo $REGION | grep -q "None"; then
 fi
 
 message "Setting Cache-Control Max-Age $MAXAGE for all assets in S3 Bucket $BUCKET"
-set=$(aws s3 cp --recursive --profile $profile --region $REGION s3://$BUCKET/ s3://$BUCKET/ --cache-control "public, max-age=$MAXAGE" --metadata-directive "REPLACE" 2>&1)
+set=$(aws s3 cp --recursive --region $REGION s3://$BUCKET/ s3://$BUCKET/ --cache-control "public, max-age=$MAXAGE" --metadata-directive "REPLACE" 2>&1)
 if [ ! $? -eq 0 ]; then
 	fail "$set"
 fi

--- a/vpc-eni-monitor.sh
+++ b/vpc-eni-monitor.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will generate an HTML page to monitor the number of AWS VPC Elastic Network Interfaces currently in use and upload it to an S3 bucket website
 # Requires the AWS CLI, jq
 
@@ -46,7 +53,7 @@ fi
 function validateVPCID(){
 	if [ "$VPCID" = "YOUR-VPC-ID-HERE" ] || [ -z "$VPCID" ]; then
 		# Count number of VPCs
-		DESCRIBEVPCS=$(aws ec2 describe-vpcs --profile $PROFILE1 2>&1)
+		DESCRIBEVPCS=$(aws ec2 describe-vpcs1 2>&1)
 		if echo $DESCRIBEVPCS | egrep -q "Error|error|not"; then
 			fail "$DESCRIBEVPCS"
 		fi
@@ -59,7 +66,7 @@ function validateVPCID(){
 		if [ "$NUMVPCS" -eq "1" ]; then
 			VPCID=$(echo "$DESCRIBEVPCS" | jq '.Vpcs | .[] | .VpcId' | cut -d \" -f2)
 		else
-			FOUNDVPCS=$(aws ec2 describe-vpcs --profile $PROFILE1 2>&1 | jq '.Vpcs | .[] | .VpcId')
+			FOUNDVPCS=$(aws ec2 describe-vpcs1 2>&1 | jq '.Vpcs | .[] | .VpcId')
 			if echo $FOUNDVPCS | egrep -q "Error|error|not|invalid"; then
 				fail "$FOUNDVPCS"
 			fi
@@ -71,7 +78,7 @@ function validateVPCID(){
 			fi
 		fi
 	fi
-	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" --profile $PROFILE1 2>&1)
+	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID"1 2>&1)
 
 	# Test for error
 	if ! echo "$CHECKVPC" | grep -q "available"; then
@@ -87,7 +94,7 @@ function validateVPCID(){
 function generateHTML(){
 	while :
 	do
-		ENI=$(aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$VPCID --profile $PROFILE1 2>&1 | jq '.NetworkInterfaces | .[] | .NetworkInterfaceId' | wc -l | rev | cut -d ' ' -f1 | rev)
+		ENI=$(aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$VPCID1 2>&1 | jq '.NetworkInterfaces | .[] | .NetworkInterfaceId' | wc -l | rev | cut -d ' ' -f1 | rev)
 		if echo $ENI | grep -q error; then
 			fail "$ENI"
 		fi
@@ -157,7 +164,7 @@ EOP
 EOP
 		) >> $HTMLFILENAME
 
-		UPLOAD=$(aws s3 cp $HTMLFILENAME $S3BUCKETPATH --profile $PROFILE2 2>&1)
+		UPLOAD=$(aws s3 cp $HTMLFILENAME $S3BUCKETPATH2 2>&1)
 		if echo $UPLOAD | egrep -q "Error|error|not"; then
 			fail "$UPLOAD"
 		fi

--- a/vpc-sg-import-rules-cloudflare.sh
+++ b/vpc-sg-import-rules-cloudflare.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # Create VPC Security Group with Cloudflare IP ranges
 # Requires curl, jq
 
@@ -56,7 +63,7 @@ else
 fi
 
 # Validate AWS CLI profile
-if ! aws sts get-caller-identity --profile $profile 2>&1 | grep -q "UserId"; then
+if ! aws sts get-caller-identity 2>&1 | grep -q "UserId"; then
 	fail "Invalid AWS CLI profile or credentials not setup. Please run \"aws configure\"."
 fi
 
@@ -67,7 +74,7 @@ function validateVPCID(){
 	fi
 	if [ "$VPCID" = "YOUR-VPC-ID-HERE" ] || [ -z "$VPCID" ]; then
 		# Count number of VPCs
-		DESCRIBEVPCS=$(aws ec2 describe-vpcs --profile $profile 2>&1)
+		DESCRIBEVPCS=$(aws ec2 describe-vpcs 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$DESCRIBEVPCS"
 		fi
@@ -102,7 +109,7 @@ function validateVPCID(){
 			HorizontalRule
 			# Get VPC Names
 			for vpcid in $FOUNDVPCS; do
-				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" --profile $profile 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
+				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
 			done
 			echo
 			read -r -p "Please specify VPC ID (ex. vpc-abcd1234): " VPCID
@@ -112,7 +119,7 @@ function validateVPCID(){
 		fi
 	fi
 
-	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" --profile $profile 2>&1)
+	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$CHECKVPC"
 	fi
@@ -172,16 +179,16 @@ fi
 
 function checkGroups (){
 	# Check for existing security group or create new one
-	checkGroups=$(aws ec2 describe-security-groups --output=json --profile $profile 2>&1 | jq '.SecurityGroups | .[] | .GroupName')
+	checkGroups=$(aws ec2 describe-security-groups --output=json 2>&1 | jq '.SecurityGroups | .[] | .GroupName')
 	if ! echo "$checkGroups" | grep -q "$GROUPNAME"; then
 		echo
 		echo "====================================================="
 		echo "Creating Security Group: "$GROUPNAME
-		GROUPID=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCRIPTION" --vpc-id $VPCID --profile $profile 2>&1 | jq '.GroupId' | cut -d '"' -f2)
+		GROUPID=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCRIPTION" --vpc-id $VPCID 2>&1 | jq '.GroupId' | cut -d '"' -f2)
 		if $DEBUG; then
 			echo "GROUPID: $GROUPID"
 		fi
-		aws ec2 create-tags --resources $(aws ec2 describe-security-groups --output=json --profile $profile 2>&1 | jq '.SecurityGroups | .[] | select(.GroupName=="'"$GROUPNAME"'") | .GroupId' | cut -d '"' -f2) --tags Key=Name,Value="$GROUPNAME" --profile $profile 2>&1
+		aws ec2 create-tags --resources $(aws ec2 describe-security-groups --output=json 2>&1 | jq '.SecurityGroups | .[] | select(.GroupName=="'"$GROUPNAME"'") | .GroupId' | cut -d '"' -f2) --tags Key=Name,Value="$GROUPNAME" 2>&1
 		echo "====================================================="
 
 		addRules
@@ -190,7 +197,7 @@ function checkGroups (){
 		echo
 		echo "====================================================="
 		echo "Group $GROUPNAME Already Exists"
-		GROUPID=$(aws ec2 describe-security-groups --output=json --profile $profile 2>&1 | jq '.SecurityGroups | .[] | select(.GroupName=="'"$GROUPNAME"'") | .GroupId' | cut -d '"' -f2)
+		GROUPID=$(aws ec2 describe-security-groups --output=json 2>&1 | jq '.SecurityGroups | .[] | select(.GroupName=="'"$GROUPNAME"'") | .GroupId' | cut -d '"' -f2)
 		echo "Security Group ID: $GROUPID"
 		read -r -p "Do you want to delete the group and recreate it? (y/n) " DELETEGROUP
 		if [[ $DELETEGROUP =~ ^([yY][eE][sS]|[yY])$ ]]; then
@@ -199,16 +206,16 @@ function checkGroups (){
 			echo "Deleting Group Name: $GROUPNAME"
 			echo "Security Group ID: $GROUPID"
 			echo "====================================================="
-			DELETEGROUP=$(aws ec2 delete-security-group --group-id "$GROUPID" --profile $profile 2>&1)
+			DELETEGROUP=$(aws ec2 delete-security-group --group-id "$GROUPID" 2>&1)
 			if echo $DELETEGROUP | grep -q error; then
 				fail $DELETEGROUP
 			else
 				echo
 				echo "====================================================="
 				echo "Creating Security Group: "$GROUPNAME
-				GROUPID=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCRIPTION" --vpc-id $VPCID --profile $profile 2>&1 | jq '.GroupId' | cut -d '"' -f2)
+				GROUPID=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCRIPTION" --vpc-id $VPCID 2>&1 | jq '.GroupId' | cut -d '"' -f2)
 				echo $GROUPID
-				aws ec2 create-tags --resources $(aws ec2 describe-security-groups --output=json --profile $profile 2>&1 | jq '.SecurityGroups | .[] | select(.GroupName=="'"$GROUPNAME"'") | .GroupId' | cut -d '"' -f2) --tags Key=Name,Value="$GROUPNAME" --profile $profile 2>&1
+				aws ec2 create-tags --resources $(aws ec2 describe-security-groups --output=json 2>&1 | jq '.SecurityGroups | .[] | select(.GroupName=="'"$GROUPNAME"'") | .GroupId' | cut -d '"' -f2) --tags Key=Name,Value="$GROUPNAME" 2>&1
 				echo "====================================================="
 
 				addRules
@@ -257,7 +264,7 @@ function addRules (){
 				# 	echo "IP: $ip"
 				# fi
 				echo "IP: $ip Port: $PORT Protocol: $PROTO"
-				RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --protocol $PROTO --port $PORT --cidr "$ip" --profile $profile 2>&1)
+				RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --protocol $PROTO --port $PORT --cidr "$ip" 2>&1)
 				# Check for errors
 				if echo "$RESULT" | grep -q error; then
 					echo "$RESULT"
@@ -278,7 +285,7 @@ function addRules (){
 				fail "Invalid PORT value: $PORT It should be a single numeric value or a range in the form <from[-to]>."
 			fi
 			echo "IP: $ip Port: $PORT Protocol: $PROTO"
-			RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --protocol $PROTO --port $PORT --cidr "$ip" --profile $profile 2>&1)
+			RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --protocol $PROTO --port $PORT --cidr "$ip" 2>&1)
 			# Check for errors
 			if echo "$RESULT" | grep -q error; then
 				echo "$RESULT"
@@ -319,8 +326,8 @@ function addRulesV6 (){
 			for ip in $IPLIST
 			do
 				echo "IP: $ip Port: $PORT Protocol: $PROTO"
-				# RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --protocol $PROTO --port $PORT --cidr "$ip" --profile $profile 2>&1)
-				RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --ip-permissions IpProtocol=$PROTO,FromPort=$PORT,ToPort=$PORT,Ipv6Ranges=[{CidrIpv6="$ip"}] --profile $profile 2>&1)
+				# RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --protocol $PROTO --port $PORT --cidr "$ip" 2>&1)
+				RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --ip-permissions IpProtocol=$PROTO,FromPort=$PORT,ToPort=$PORT,Ipv6Ranges=[{CidrIpv6="$ip"}] 2>&1)
 				# Check for errors
 				if echo "$RESULT" | grep -q error; then
 					echo "$RESULT"
@@ -338,8 +345,8 @@ function addRulesV6 (){
 				fail "Invalid PORT value: $PORT It should be a single numeric value or a range in the form <from[-to]>."
 			fi
 			echo "IP: $ip Port: $PORT Protocol: $PROTO"
-			# RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --protocol $PROTO --port $PORT --cidr "$ip" --profile $profile 2>&1)
-			RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --ip-permissions IpProtocol=$PROTO,FromPort=$PORT,ToPort=$PORT,Ipv6Ranges=[{CidrIpv6="$ip"}] --profile $profile 2>&1)
+			# RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --protocol $PROTO --port $PORT --cidr "$ip" 2>&1)
+			RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --ip-permissions IpProtocol=$PROTO,FromPort=$PORT,ToPort=$PORT,Ipv6Ranges=[{CidrIpv6="$ip"}] 2>&1)
 			# Check for errors
 			if echo "$RESULT" | grep -q error; then
 				echo "$RESULT"
@@ -362,7 +369,7 @@ checkGroups
 echo "====================================================="
 echo
 
-confirmGroups=$(aws ec2 describe-security-groups --output=json --profile $profile 2>&1 | jq '.SecurityGroups | .[] | .GroupName')
+confirmGroups=$(aws ec2 describe-security-groups --output=json 2>&1 | jq '.SecurityGroups | .[] | .GroupName')
 if ! echo "$confirmGroups" | grep -q "$GROUPNAME"; then
 	fail "Failed to create security group!"
 else

--- a/vpc-sg-import-rules-cloudfront.sh
+++ b/vpc-sg-import-rules-cloudfront.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # Create VPC Security Group with CloudFront IP ranges
 
 # Get current list of CloudFront IP ranges
@@ -84,7 +91,7 @@ function validateVPCID(){
 	fi
 	if [ "$VPCID" = "YOUR-VPC-ID-HERE" ] || [ -z "$VPCID" ]; then
 		# Count number of VPCs
-		DESCRIBEVPCS=$(aws ec2 describe-vpcs --profile $profile 2>&1)
+		DESCRIBEVPCS=$(aws ec2 describe-vpcs 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$DESCRIBEVPCS"
 		fi
@@ -119,7 +126,7 @@ function validateVPCID(){
 			HorizontalRule
 			# Get VPC Names
 			for vpcid in $FOUNDVPCS; do
-				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" --profile $profile 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
+				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
 			done
 			echo
 			read -r -p "Please specify VPC ID (ex. vpc-abcd1234): " VPCID
@@ -129,7 +136,7 @@ function validateVPCID(){
 		fi
 	fi
 
-	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" --profile $profile 2>&1)
+	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$CHECKVPC"
 	fi
@@ -154,7 +161,7 @@ function checkExisting(){
 		echo "GROUPNAMETITLE: $GROUPNAMETITLE"
 	fi
 
-	DESCRIBEGROUPS=$(aws ec2 describe-security-groups --filters Name=vpc-id,Values="$VPCID" --output=json --profile $profile 2>&1)
+	DESCRIBEGROUPS=$(aws ec2 describe-security-groups --filters Name=vpc-id,Values="$VPCID" --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$DESCRIBEGROUPS"
 	fi
@@ -200,7 +207,7 @@ function deleteExisting(){
 		HorizontalRule
 		echo "Deleting Security Group ID: $GROUPID"
 		HorizontalRule
-		DELETEGROUP=$(aws ec2 delete-security-group --group-id "$GROUPID" --profile $profile 2>&1)
+		DELETEGROUP=$(aws ec2 delete-security-group --group-id "$GROUPID" 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$GROUPID"
 		fi
@@ -219,14 +226,14 @@ function createGroup(){
 	echo
 	HorizontalRule
 	echo "Creating Security Group "$GROUPNAME
-	GROUPID=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCR" --vpc-id "$VPCID" --profile $profile 2>&1)
+	GROUPID=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCR" --vpc-id "$VPCID" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$GROUPID"
 	else
 		GROUPID=$(echo "$GROUPID" | jq '.GroupId' | cut -d \" -f2)
 	fi
 	echo "ID: $GROUPID"
-	TAGS=$(aws ec2 create-tags --resources "$GROUPID" --tags Key=Name,Value="$GROUPNAME" --profile $profile 2>&1)
+	TAGS=$(aws ec2 create-tags --resources "$GROUPID" --tags Key=Name,Value="$GROUPNAME" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$TAGS"
 	fi
@@ -243,7 +250,7 @@ function addRules(){
 	echo
 	for ip in $IPLIST
 	do
-		RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --protocol $PROTO --port $PORT --cidr "$ip" --profile $profile 2>&1)
+		RESULT=$(aws ec2 authorize-security-group-ingress --group-id "$GROUPID" --protocol $PROTO --port $PORT --cidr "$ip" 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$RESULT"
 		fi

--- a/vpc-sg-import-rules-pingdom.sh
+++ b/vpc-sg-import-rules-pingdom.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will save a list of current Pingdom IPv4 probe server IPs in the file pingdom-probe-servers.txt
 # Then create an AWS VPC Security Group with rules to allow access to each IP at the port specified.
 
@@ -118,7 +125,7 @@ function createGroups(){
 	echo
 	HorizontalRule
 	echo "Creating Security Group: $1 $FROMPORT"
-	SGID=$(aws ec2 create-security-group --group-name "$1 $FROMPORT" --description "$2" --vpc-id $VPCID --profile $profile 2>&1 | jq '.GroupId' | cut -d \" -f2)
+	SGID=$(aws ec2 create-security-group --group-name "$1 $FROMPORT" --description "$2" --vpc-id $VPCID 2>&1 | jq '.GroupId' | cut -d \" -f2)
 	if [ ! $? -eq 0 ]; then
 		fail "$SGID"
 	fi
@@ -126,7 +133,7 @@ function createGroups(){
 		fail "$SGID"
 	fi
 	echo "Security Group ID:" $SGID
-	TAG=$(aws ec2 create-tags --resources $SGID --tags Key=Name,Value="$1" --profile $profile 2>&1)
+	TAG=$(aws ec2 create-tags --resources $SGID --tags Key=Name,Value="$1" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$TAG"
 	fi
@@ -465,7 +472,7 @@ function AuthorizeSecurityGroupIngress(){
 	echo "Adding rules to security groups..."
 	HorizontalRule
 	echo
-	AUTHORIZE=$(aws ec2 authorize-security-group-ingress --cli-input-json "$json" --profile $profile 2>&1)
+	AUTHORIZE=$(aws ec2 authorize-security-group-ingress --cli-input-json "$json" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$AUTHORIZE"
 	fi
@@ -568,7 +575,7 @@ function validateVPCID(){
 	fi
 	if [ "$VPCID" = "YOUR-VPC-ID-HERE" ] || [ -z "$VPCID" ]; then
 		# Count number of VPCs
-		DESCRIBEVPCS=$(aws ec2 describe-vpcs --profile $profile 2>&1)
+		DESCRIBEVPCS=$(aws ec2 describe-vpcs 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$DESCRIBEVPCS"
 		fi
@@ -603,7 +610,7 @@ function validateVPCID(){
 			HorizontalRule
 			# Get VPC Names
 			for vpcid in $FOUNDVPCS; do
-				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" --profile $profile 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
+				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
 			done
 			echo
 			read -r -p "Please specify VPC ID (ex. vpc-abcd1234): " VPCID
@@ -613,7 +620,7 @@ function validateVPCID(){
 		fi
 	fi
 
-	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" --profile $profile 2>&1)
+	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$CHECKVPC"
 	fi
@@ -630,7 +637,7 @@ function validateGroupName(){
 		echo "function validateGroupName"
 		echo "GROUPNAME $GROUPNAME"
 	fi
-	validateGroupName=$(aws ec2 describe-security-groups --filters Name=vpc-id,Values="$VPCID" --output=json --profile $profile 2>&1 | jq '.SecurityGroups | .[] | .GroupName')
+	validateGroupName=$(aws ec2 describe-security-groups --filters Name=vpc-id,Values="$VPCID" --output=json 2>&1 | jq '.SecurityGroups | .[] | .GroupName')
 	if [ ! $? -eq 0 ]; then
 		fail "$validateGroupName"
 	fi
@@ -652,7 +659,7 @@ function validateGroupName(){
 
 # Look up the security group IDs
 function findGroups(){
-	FindGroups=$(aws ec2 describe-security-groups --filters Name=vpc-id,Values="$VPCID" --output=json --profile $profile 2>&1)
+	FindGroups=$(aws ec2 describe-security-groups --filters Name=vpc-id,Values="$VPCID" --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$FindGroups"
 	fi
@@ -678,7 +685,7 @@ function findGroups(){
 
 # Remove the existing IPs and add new IPs
 function deleteIPs(){
-	FindGroups=$(aws ec2 describe-security-groups --filters Name=vpc-id,Values="$VPCID" --output=json --profile $profile 2>&1)
+	FindGroups=$(aws ec2 describe-security-groups --filters Name=vpc-id,Values="$VPCID" --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$FindGroups"
 	fi
@@ -710,15 +717,15 @@ function deleteIPs(){
 		fi
 	fi
 
-	Group1=$(aws ec2 describe-security-groups --output=json --group-id "$SGID1" --profile $profile 2>&1)
+	Group1=$(aws ec2 describe-security-groups --output=json --group-id "$SGID1" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$Group1"
 	fi
-	Group2=$(aws ec2 describe-security-groups --output=json --group-id "$SGID2" --profile $profile 2>&1)
+	Group2=$(aws ec2 describe-security-groups --output=json --group-id "$SGID2" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$Group2"
 	fi
-	# Group3IPs=$(aws ec2 describe-security-groups --output=json --group-id "$SGID3" --profile $profile 2>&1)
+	# Group3IPs=$(aws ec2 describe-security-groups --output=json --group-id "$SGID3" 2>&1)
 	# if [ ! $? -eq 0 ]; then
 	# 	fail "$Group3IPs"
 	# fi
@@ -749,7 +756,7 @@ function deleteIPs(){
 	echo
 	HorizontalRule
 	echo "Removing IPs from $Group1Name, Security Group ID $SGID1"
-	RemoveGroup1IPs=$(aws ec2 revoke-security-group-ingress --output=json --group-id "$SGID1" --profile $profile --ip-permissions "$Group1IPs" 2>&1)
+	RemoveGroup1IPs=$(aws ec2 revoke-security-group-ingress --output=json --group-id "$SGID1" --ip-permissions "$Group1IPs" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$RemoveGroup1IPs"
 	fi
@@ -758,7 +765,7 @@ function deleteIPs(){
 	echo
 	HorizontalRule
 	echo "Removing IPs from $Group2Name, Security Group ID $SGID2"
-	RemoveGroup2IPs=$(aws ec2 revoke-security-group-ingress --output=json --group-id "$SGID2" --profile $profile --ip-permissions "$Group2IPs" 2>&1)
+	RemoveGroup2IPs=$(aws ec2 revoke-security-group-ingress --output=json --group-id "$SGID2" --ip-permissions "$Group2IPs" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$RemoveGroup2IPs"
 	fi
@@ -767,7 +774,7 @@ function deleteIPs(){
 	# echo
 	# HorizontalRule
 	# echo "Removing IPs from $Group3Name, Security Group ID $SGID3"
-	# RemoveGroup3IPs=$(aws ec2 revoke-security-group-ingress --output=json --group-id "$SGID3" --profile $profile --ip-permissions "$Group3IPs" 2>&1)
+	# RemoveGroup3IPs=$(aws ec2 revoke-security-group-ingress --output=json --group-id "$SGID3" --ip-permissions "$Group3IPs" 2>&1)
 	# if [ ! $? -eq 0 ]; then
 	# 	fail "$RemoveGroup3IPs"
 	# fi

--- a/vpc-sg-import-rules.sh
+++ b/vpc-sg-import-rules.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will read from the list of IPs in the file iplist
 # Then create an AWS VPC Security Group with rules to allow access to each IP at the port specified
 # Due to AWS limits a group can only have 50 rules and will create multiple groups if greater than 50 rules
@@ -76,7 +83,7 @@ function validateVPCID(){
 	fi
 	if [ "$VPCID" = "YOUR-VPC-ID-HERE" ] || [ -z "$VPCID" ]; then
 		# Count number of VPCs
-		DESCRIBEVPCS=$(aws ec2 describe-vpcs --profile $profile 2>&1)
+		DESCRIBEVPCS=$(aws ec2 describe-vpcs 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$DESCRIBEVPCS"
 		fi
@@ -111,7 +118,7 @@ function validateVPCID(){
 			HorizontalRule
 			# Get VPC Names
 			for vpcid in $FOUNDVPCS; do
-				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" --profile $profile 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
+				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
 			done
 			echo
 			read -r -p "Please specify VPC ID (ex. vpc-abcd1234): " VPCID
@@ -121,7 +128,7 @@ function validateVPCID(){
 		fi
 	fi
 
-	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" --profile $profile 2>&1)
+	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$CHECKVPC"
 	fi
@@ -136,7 +143,7 @@ function createGroup(){
 	echo
 	HorizontalRule
 	echo "Creating Security Group "$GROUPNAME
-	creategroup=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCR" --vpc-id $VPCID --profile $profile 2>&1)
+	creategroup=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCR" --vpc-id $VPCID 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$creategroup"
 	fi
@@ -145,7 +152,7 @@ function createGroup(){
 		fail "$SGID"
 	fi
 	echo "Security Group ID: $SGID"
-	TAG=$(aws ec2 create-tags --resources $SGID --tags Key=Name,Value="$GROUPNAME" --profile $profile 2>&1)
+	TAG=$(aws ec2 create-tags --resources $SGID --tags Key=Name,Value="$GROUPNAME" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$TAG"
 	fi
@@ -154,7 +161,7 @@ function createGroup(){
 }
 
 function addRule(){
-	addrule=$(aws ec2 authorize-security-group-ingress --group-name "$GROUPNAME" --protocol $PROTO --port $PORT --cidr "$iplist/32" --profile $profile 2>&1)
+	addrule=$(aws ec2 authorize-security-group-ingress --group-name "$GROUPNAME" --protocol $PROTO --port $PORT --cidr "$iplist/32" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$addrule"
 	fi

--- a/vpc-sg-merge-groups.sh
+++ b/vpc-sg-merge-groups.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will merge two existing VPC Security Groups together into one single group
 # Security Groups must exist in the same VPC, total rules must be 50 or less
 # Any duplicate rules in the two groups will cause an error
@@ -78,7 +85,7 @@ function validateVPCID(){
 	fi
 	if [ "$VPCID" = "YOUR-VPC-ID-HERE" ] || [ -z "$VPCID" ]; then
 		# Count number of VPCs
-		DESCRIBEVPCS=$(aws ec2 describe-vpcs --profile $profile 2>&1)
+		DESCRIBEVPCS=$(aws ec2 describe-vpcs 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$DESCRIBEVPCS"
 		fi
@@ -113,7 +120,7 @@ function validateVPCID(){
 			HorizontalRule
 			# Get VPC Names
 			for vpcid in $FOUNDVPCS; do
-				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" --profile $profile 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
+				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
 			done
 			echo
 			read -r -p "Please specify VPC ID (ex. vpc-abcd1234): " VPCID
@@ -123,7 +130,7 @@ function validateVPCID(){
 		fi
 	fi
 
-	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" --profile $profile 2>&1)
+	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$CHECKVPC"
 	fi
@@ -136,7 +143,7 @@ function validateVPCID(){
 
 # Describe Security Groups
 function describeSGS(){
-	describeSGS=$(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=$VPCID" --output=json --profile $profile 2>&1) # | jq '.SecurityGroups | .[] | .GroupName')
+	describeSGS=$(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=$VPCID" --output=json 2>&1) # | jq '.SecurityGroups | .[] | .GroupName')
 	if [ ! $? -eq 0 ]; then
 		fail "$describeSGS"
 	fi
@@ -150,8 +157,8 @@ function describeSGS(){
 	HorizontalRule
 	# Get SG Names
 	for sgid in $sgIDs; do
-		echo $sgid - Group Name: $(aws ec2 describe-security-groups --group-ids $sgid --profile $profile 2>&1 | jq '.SecurityGroups | .[] | .GroupName' | cut -d \" -f2)
-		# echo $sgid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$sgid" "Name=key,Values=Name" --profile $profile 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
+		echo $sgid - Group Name: $(aws ec2 describe-security-groups --group-ids $sgid 2>&1 | jq '.SecurityGroups | .[] | .GroupName' | cut -d \" -f2)
+		# echo $sgid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$sgid" "Name=key,Values=Name" 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
 	done
 	echo
 }
@@ -163,7 +170,7 @@ function selectSGS(){
 	if [ -z "$SGID1" ]; then
 		fail "Must specify a valid Security Group ID."
 	fi
-	describeSGID1=$(aws ec2 describe-security-groups --group-ids $SGID1 --profile $profile 2>&1)
+	describeSGID1=$(aws ec2 describe-security-groups --group-ids $SGID1 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$describeSGID1"
 	fi
@@ -175,7 +182,7 @@ function selectSGS(){
 	if [ -z "$SGID2" ]; then
 		fail "Must specify a valid Security Group ID."
 	fi
-	describeSGID2=$(aws ec2 describe-security-groups --group-ids $SGID2 --profile $profile 2>&1)
+	describeSGID2=$(aws ec2 describe-security-groups --group-ids $SGID2 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$describeSGID2"
 	fi
@@ -193,7 +200,7 @@ function createGroup(){
 	echo
 	HorizontalRule
 	echo "Creating Security Group: $1"
-	createGroup=$(aws ec2 create-security-group --group-name "$1" --description "$1" --vpc-id $VPCID --profile $profile 2>&1)
+	createGroup=$(aws ec2 create-security-group --group-name "$1" --description "$1" --vpc-id $VPCID 2>&1)
 	if echo $createGroup | grep -q 'InvalidGroup.Duplicate'; then
 		tput setaf 1; echo "Error: The security group $1 already exists." && tput sgr0
 		HorizontalRule
@@ -201,7 +208,7 @@ function createGroup(){
 		DATE=$(date +%m-%d-%Y)
 		GROUPNAME="$1-$DATE"
 		echo "Creating Security Group: $GROUPNAME"
-		createGroup=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$1" --vpc-id $VPCID --profile $profile 2>&1)
+		createGroup=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$1" --vpc-id $VPCID 2>&1)
 	fi
 	if [ ! $? -eq 0 ]; then
 		fail "$createGroup"
@@ -217,7 +224,7 @@ function createGroup(){
 		fail "$SGID"
 	fi
 	echo "New Security Group ID:" $SGID
-	TAG=$(aws ec2 create-tags --resources $SGID --tags Key=Name,Value="$1" --profile $profile 2>&1)
+	TAG=$(aws ec2 create-tags --resources $SGID --tags Key=Name,Value="$1" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$TAG"
 	fi
@@ -238,7 +245,7 @@ function AuthorizeSecurityGroupIngress(){
 	HorizontalRule
 	echo
 	json=$(cat "$1")
-	AUTHORIZE=$(aws ec2 authorize-security-group-ingress --cli-input-json "$json" --profile $profile 2>&1)
+	AUTHORIZE=$(aws ec2 authorize-security-group-ingress --cli-input-json "$json" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$AUTHORIZE"
 	fi
@@ -257,7 +264,7 @@ function AuthorizeSecurityGroupEgress(){
 	HorizontalRule
 	echo
 	json=$(cat "$1")
-	AUTHORIZE=$(aws ec2 authorize-security-group-egress --cli-input-json "$json" --profile $profile 2>&1)
+	AUTHORIZE=$(aws ec2 authorize-security-group-egress --cli-input-json "$json" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$AUTHORIZE"
 	fi
@@ -380,7 +387,7 @@ SGEGRESSTEST1=$(cat SGEGRESS1 | jq '.IpPermissions' > SGEGRESSTEST1)
 if [ ! $? -eq 0 ]; then
 	fail "$SGEGRESSTEST1"
 fi
-SGEGRESSTEST2=$(aws ec2 describe-security-groups --group-ids "$SGID" --profile $profile 2>&1 | jq '.SecurityGroups | .[] | .IpPermissionsEgress' > SGEGRESSTEST2)
+SGEGRESSTEST2=$(aws ec2 describe-security-groups --group-ids "$SGID" 2>&1 | jq '.SecurityGroups | .[] | .IpPermissionsEgress' > SGEGRESSTEST2)
 if [ ! $? -eq 0 ]; then
 	fail "$SGEGRESSTEST2"
 fi

--- a/vpc-sg-rename-group.sh
+++ b/vpc-sg-rename-group.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will rename an existing VPC Security Group by creating an identical new group
 # Security Groups must exist in the same VPC and region
 # Note: this script is somewhat experimental and you should manually verify all results before applying the new group!!!
@@ -77,7 +84,7 @@ function validateVPCID(){
 	fi
 	if [ "$VPCID" = "YOUR-VPC-ID-HERE" ] || [ -z "$VPCID" ]; then
 		# Count number of VPCs
-		DESCRIBEVPCS=$(aws ec2 describe-vpcs --profile $profile 2>&1)
+		DESCRIBEVPCS=$(aws ec2 describe-vpcs 2>&1)
 		if [ ! $? -eq 0 ]; then
 			fail "$DESCRIBEVPCS"
 		fi
@@ -112,7 +119,7 @@ function validateVPCID(){
 			HorizontalRule
 			# Get VPC Names
 			for vpcid in $FOUNDVPCS; do
-				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" --profile $profile 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
+				echo $vpcid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$vpcid" "Name=key,Values=Name" 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
 			done
 			echo
 			read -r -p "Please specify VPC ID (ex. vpc-abcd1234): " VPCID
@@ -122,7 +129,7 @@ function validateVPCID(){
 		fi
 	fi
 
-	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" --profile $profile 2>&1)
+	CHECKVPC=$(aws ec2 describe-vpcs --vpc-ids "$VPCID" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$CHECKVPC"
 	fi
@@ -135,7 +142,7 @@ function validateVPCID(){
 
 # Describe Security Groups
 function describeSGS(){
-	describeSGS=$(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=$VPCID" --output=json --profile $profile 2>&1) # | jq '.SecurityGroups | .[] | .GroupName')
+	describeSGS=$(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=$VPCID" --output=json 2>&1) # | jq '.SecurityGroups | .[] | .GroupName')
 	if [ ! $? -eq 0 ]; then
 		fail "$describeSGS"
 	fi
@@ -149,8 +156,8 @@ function describeSGS(){
 	HorizontalRule
 	# Get SG Names
 	for sgid in $sgIDs; do
-		echo $sgid - Group Name: $(aws ec2 describe-security-groups --group-ids $sgid --profile $profile 2>&1 | jq '.SecurityGroups | .[] | .GroupName' | cut -d \" -f2)
-		# echo $sgid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$sgid" "Name=key,Values=Name" --profile $profile 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
+		echo $sgid - Group Name: $(aws ec2 describe-security-groups --group-ids $sgid 2>&1 | jq '.SecurityGroups | .[] | .GroupName' | cut -d \" -f2)
+		# echo $sgid - Name: $(aws ec2 describe-tags --filters "Name=resource-id,Values=$sgid" "Name=key,Values=Name" 2>&1 | jq '.Tags | .[] | .Value' | cut -d \" -f2)
 	done
 	echo
 }
@@ -162,7 +169,7 @@ function selectSGS(){
 	if [ -z "$SGID1" ]; then
 		fail "Must specify a valid Security Group ID."
 	fi
-	describeSGID1=$(aws ec2 describe-security-groups --group-ids $SGID1 --profile $profile 2>&1)
+	describeSGID1=$(aws ec2 describe-security-groups --group-ids $SGID1 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$describeSGID1"
 	fi
@@ -185,7 +192,7 @@ function createGroup(){
 	echo
 	HorizontalRule
 	echo "Creating Security Group: $1"
-	createGroup=$(aws ec2 create-security-group --group-name "$1" --description "$2" --vpc-id $VPCID --profile $profile 2>&1)
+	createGroup=$(aws ec2 create-security-group --group-name "$1" --description "$2" --vpc-id $VPCID 2>&1)
 	if echo $createGroup | grep -q 'InvalidGroup.Duplicate'; then
 		tput setaf 1; echo "Error: The security group $1 already exists." && tput sgr0
 		HorizontalRule
@@ -193,7 +200,7 @@ function createGroup(){
 		DATE=$(date +%m-%d-%Y)
 		GROUPNAME="$1-$DATE"
 		echo "Creating Security Group: $GROUPNAME"
-		createGroup=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$2" --vpc-id $VPCID --profile $profile 2>&1)
+		createGroup=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$2" --vpc-id $VPCID 2>&1)
 	fi
 	if [ ! $? -eq 0 ]; then
 		fail "$createGroup"
@@ -209,7 +216,7 @@ function createGroup(){
 		fail "$SGID"
 	fi
 	echo "New Security Group ID:" $SGID
-	TAG=$(aws ec2 create-tags --resources $SGID --tags Key=Name,Value="$1" --profile $profile 2>&1)
+	TAG=$(aws ec2 create-tags --resources $SGID --tags Key=Name,Value="$1" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$TAG"
 	fi
@@ -218,7 +225,7 @@ function createGroup(){
 	fi
 	HorizontalRule
 	echo
-	describeNewSG=$(aws ec2 describe-security-groups --group-ids $SGID --profile $profile 2>&1)
+	describeNewSG=$(aws ec2 describe-security-groups --group-ids $SGID 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$describeNewSG"
 	fi
@@ -236,7 +243,7 @@ function AuthorizeSecurityGroupIngress(){
 	HorizontalRule
 	echo
 	json=$(cat "$1")
-	AUTHORIZE=$(aws ec2 authorize-security-group-ingress --cli-input-json "$json" --profile $profile 2>&1)
+	AUTHORIZE=$(aws ec2 authorize-security-group-ingress --cli-input-json "$json" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$AUTHORIZE"
 	fi
@@ -255,7 +262,7 @@ function RevokeSecurityGroupEgress(){
 	HorizontalRule
 	echo
 	json=$(cat "$1")
-	REVOKE=$(aws ec2 revoke-security-group-egress --cli-input-json "$json" --profile $profile 2>&1)
+	REVOKE=$(aws ec2 revoke-security-group-egress --cli-input-json "$json" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$REVOKE"
 	fi
@@ -274,7 +281,7 @@ function AuthorizeSecurityGroupEgress(){
 	HorizontalRule
 	echo
 	json=$(cat "$1")
-	AUTHORIZE=$(aws ec2 authorize-security-group-egress --cli-input-json "$json" --profile $profile 2>&1)
+	AUTHORIZE=$(aws ec2 authorize-security-group-egress --cli-input-json "$json" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$AUTHORIZE"
 	fi
@@ -394,7 +401,7 @@ if [[ $DEBUGMODE = "1" ]]; then
 	echo SGEGRESSTEST1:
 	cat SGEGRESSTEST1
 fi
-SGEGRESSTEST2=$(aws ec2 describe-security-groups --group-ids "$SGID" --profile $profile 2>&1 | jq '.SecurityGroups | .[] | .IpPermissionsEgress' > SGEGRESSTEST2)
+SGEGRESSTEST2=$(aws ec2 describe-security-groups --group-ids "$SGID" 2>&1 | jq '.SecurityGroups | .[] | .IpPermissionsEgress' > SGEGRESSTEST2)
 if [ ! $? -eq 0 ]; then
 	fail "$SGEGRESSTEST2"
 fi

--- a/waf-export-ip-sets.sh
+++ b/waf-export-ip-sets.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will export each AWS WAF IP set match condition to a JSON file for backup
 # Requires the AWS CLI and jq
 
@@ -63,7 +70,7 @@ fi
 
 # Get list of all IP Sets
 function ListIPSets(){
-	ListIPSets=$(aws waf list-ip-sets --output=json --profile $profile 2>&1)
+	ListIPSets=$(aws waf list-ip-sets --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$ListIPSets"
 	fi
@@ -103,7 +110,7 @@ function ListIPSets(){
 
 # Get a single IP Set
 function GetIPSet(){
-	GetIPSet=$(aws waf get-ip-set --ip-set-id "$IPSETID" --output=json --profile $profile 2>&1)
+	GetIPSet=$(aws waf get-ip-set --ip-set-id "$IPSETID" --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$GetIPSet"
 	fi

--- a/waf-web-acl-pingdom.sh
+++ b/waf-web-acl-pingdom.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will Manage WAF Web ACL to allow current Pingdom probe server IPs
 # Allows creating or updating AWS WAF IP Addresses Set, Rules and Web ACLs
 # Saves a list of current Pingdom probe server IPs in the file iplist
@@ -93,7 +100,7 @@ function GetProbeIPs(){
 
 # Gets a Change Token
 function ChangeToken(){
-	CHANGETOKEN=$(aws waf get-change-token --profile $profile 2>&1)
+	CHANGETOKEN=$(aws waf get-change-token 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$CHANGETOKEN"
 	else
@@ -109,7 +116,7 @@ function ChangeToken(){
 
 # Checks the status of a single changetoken
 function ChangeTokenStatus(){
-	CHANGETOKENSTATUS=$(aws waf get-change-token-status --change-token $CHANGETOKEN --profile $profile 2>&1 | jq '.ChangeTokenStatus' | cut -d '"' -f2)
+	CHANGETOKENSTATUS=$(aws waf get-change-token-status --change-token $CHANGETOKEN 2>&1 | jq '.ChangeTokenStatus' | cut -d '"' -f2)
 	if [ ! $? -eq 0 ]; then
 		fail "$CHANGETOKENSTATUS"
 	fi
@@ -254,7 +261,7 @@ EOP
 # Inserts a JSON file into the IP Set
 function UpdateSetInsertJSON(){
 	json=$(cat json5)
-	UPDATESET=$(aws waf update-ip-set --cli-input-json "$json" --profile $profile 2>&1)
+	UPDATESET=$(aws waf update-ip-set --cli-input-json "$json" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$UPDATESET"
 	fi
@@ -263,7 +270,7 @@ function UpdateSetInsertJSON(){
 # Deletes a JSON file from the IP Set
 function UpdateSetDeleteJSON(){
 	json=$(cat json5)
-	UPDATESET=$(aws waf update-ip-set --cli-input-json "$json" --profile $profile 2>&1)
+	UPDATESET=$(aws waf update-ip-set --cli-input-json "$json" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$UPDATESET"
 	fi
@@ -271,7 +278,7 @@ function UpdateSetDeleteJSON(){
 
 # Inserts a single IP into the IP Set
 function UpdateSetInsert(){
-	UPDATESET=$(aws waf update-ip-set --ip-set-id $IPSETID --change-token $CHANGETOKEN --updates 'Action=INSERT,IPSetDescriptor={Type=IPV4,Value="'"$iplist/32"'"}' --profile $profile 2>&1)
+	UPDATESET=$(aws waf update-ip-set --ip-set-id $IPSETID --change-token $CHANGETOKEN --updates 'Action=INSERT,IPSetDescriptor={Type=IPV4,Value="'"$iplist/32"'"}' 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$UPDATESET"
 	fi
@@ -279,7 +286,7 @@ function UpdateSetInsert(){
 
 # Deletes a single IP from the IP Set
 function UpdateSetDelete(){
-	UPDATESET=$(aws waf update-ip-set --ip-set-id $IPSETID --change-token $CHANGETOKEN --updates 'Action=DELETE,IPSetDescriptor={Type=IPV4,Value="'"$iplist"'"}' --profile $profile 2>&1)
+	UPDATESET=$(aws waf update-ip-set --ip-set-id $IPSETID --change-token $CHANGETOKEN --updates 'Action=DELETE,IPSetDescriptor={Type=IPV4,Value="'"$iplist"'"}' 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$UPDATESET"
 	fi
@@ -288,7 +295,7 @@ function UpdateSetDelete(){
 # Create IP Set
 function CreateIPSet(){
 	ChangeToken
-	IPSETID=$(aws waf create-ip-set --name "$CONDITIONNAME" --change-token $CHANGETOKEN --profile $profile 2>&1 | jq '.IPSet | .IPSetId' | cut -d '"' -f2)
+	IPSETID=$(aws waf create-ip-set --name "$CONDITIONNAME" --change-token $CHANGETOKEN 2>&1 | jq '.IPSet | .IPSetId' | cut -d '"' -f2)
 	if [ ! $? -eq 0 ]; then
 		if [[ $DEBUGMODE ]]; then
 			echo "IPSETID: "$IPSETID
@@ -300,7 +307,7 @@ function CreateIPSet(){
 
 # Get list of all IP Sets
 function ListIPSets(){
-	IPSETID=$(aws waf list-ip-sets --limit 99 --output=json --profile $profile 2>&1 | jq '.IPSets | .[] | select(.Name=="'"$CONDITIONNAME"'") | .IPSetId' | cut -d '"' -f2)
+	IPSETID=$(aws waf list-ip-sets --limit 99 --output=json 2>&1 | jq '.IPSets | .[] | select(.Name=="'"$CONDITIONNAME"'") | .IPSetId' | cut -d '"' -f2)
 	if [ ! $? -eq 0 ]; then
 		fail "$IPSETID"
 	fi
@@ -311,7 +318,7 @@ function ListIPSets(){
 
 # Get list of IPs in a single IP Set
 function GetIPSet(){
-	GetIPSet=$(aws waf get-ip-set --ip-set-id "$IPSETID" --profile $profile 2>&1 | jq '.IPSet | .IPSetDescriptors | .[] | .Value' | cut -d '"' -f2)
+	GetIPSet=$(aws waf get-ip-set --ip-set-id "$IPSETID" 2>&1 | jq '.IPSet | .IPSetDescriptors | .[] | .Value' | cut -d '"' -f2)
 	if [ ! $? -eq 0 ]; then
 		fail "$GetIPSet"
 	fi
@@ -323,7 +330,7 @@ function GetIPSet(){
 # Creates a WAF Rule
 function CreateRule(){
 	ChangeToken
-	CreateRule=$(aws waf create-rule --metric-name "$(echo $CONDITIONNAME | sed 's/[\._-]//g')" --name "Allow From $CONDITIONNAME" --change-token $CHANGETOKEN --profile $profile 2>&1)
+	CreateRule=$(aws waf create-rule --metric-name "$(echo $CONDITIONNAME | sed 's/[\._-]//g')" --name "Allow From $CONDITIONNAME" --change-token $CHANGETOKEN 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$CreateRule"
 	fi
@@ -344,7 +351,7 @@ function CreateRule(){
 # Updates a WAF Rule
 function UpdateRule(){
 	ChangeToken
-	UPDATERULE=$(aws waf update-rule --rule-id "$RULEID" --change-token $CHANGETOKEN --updates 'Action=INSERT,Predicate={Negated=false,Type=IPMatch,DataId="'"$IPSETID"'"}' --profile $profile 2>&1) # | jq '.Rule | .RuleId' | cut -d '"' -f2)
+	UPDATERULE=$(aws waf update-rule --rule-id "$RULEID" --change-token $CHANGETOKEN --updates 'Action=INSERT,Predicate={Negated=false,Type=IPMatch,DataId="'"$IPSETID"'"}' 2>&1) # | jq '.Rule | .RuleId' | cut -d '"' -f2)
 	if [ ! $? -eq 0 ]; then
 		fail "$UPDATERULE"
 	fi
@@ -362,7 +369,7 @@ function UpdateRule(){
 # Creates a WAF Web ACL
 function CreateACL(){
 	ChangeToken
-	ACLID=$(aws waf create-web-acl --metric-name "$CONDITIONNAME" --name "Allow From $CONDITIONNAME" --default-action 'Type=BLOCK' --change-token $CHANGETOKEN --profile $profile 2>&1 | jq '.WebACL | .WebACLId' | cut -d '"' -f2)
+	ACLID=$(aws waf create-web-acl --metric-name "$CONDITIONNAME" --name "Allow From $CONDITIONNAME" --default-action 'Type=BLOCK' --change-token $CHANGETOKEN 2>&1 | jq '.WebACL | .WebACLId' | cut -d '"' -f2)
 	if [ ! $? -eq 0 ]; then
 		fail "$ACLID"
 	fi
@@ -376,7 +383,7 @@ function CreateACL(){
 # Updates a WAF Web ACL
 function UpdateACL(){
 	ChangeToken
-	UPDATEACL=$(aws waf update-web-acl --web-acl-id "$ACLID" --change-token $CHANGETOKEN --updates 'Action=INSERT,ActivatedRule={Priority=0,RuleId="'"$RULEID"'",Action={Type=ALLOW}}' --profile $profile 2>&1) # | jq '.Rule | .RuleId' | cut -d '"' -f2)
+	UPDATEACL=$(aws waf update-web-acl --web-acl-id "$ACLID" --change-token $CHANGETOKEN --updates 'Action=INSERT,ActivatedRule={Priority=0,RuleId="'"$RULEID"'",Action={Type=ALLOW}}' 2>&1) # | jq '.Rule | .RuleId' | cut -d '"' -f2)
 	if [ ! $? -eq 0 ]; then
 		fail "$UPDATEACL"
 	fi
@@ -449,7 +456,7 @@ function WAF(){
 		rm changetokenlist
 	fi
 	# Check for existing IP Set with the same name and create the set if none exists
-	if ! aws waf list-ip-sets --limit 99 --output=json --profile $profile 2>&1 | jq '.IPSets | .[] | .Name' | grep -q "$CONDITIONNAME"; then
+	if ! aws waf list-ip-sets --limit 99 --output=json 2>&1 | jq '.IPSets | .[] | .Name' | grep -q "$CONDITIONNAME"; then
 		echo
 		HorizontalRule
 		echo "Creating IP Addresses Set: "$CONDITIONNAME
@@ -563,13 +570,13 @@ function WAF(){
 		# You can't delete an IPSet if it's still used in any Rules or if it still includes any IP addresses.
 		# You can't delete a Rule if it's still used in any WebACL objects.
 
-			# RULENAME=$(aws waf list-rules --limit 99 --output=json --profile $profile 2>&1 | jq '.Rules | .[] | .Name' | grep "$CONDITIONNAME" | cut -d '"' -f2)
-			# RULEID=$(aws waf list-rules --limit 99 --output=json --profile $profile 2>&1 | jq '.Rules | .[] | select(.Name=="'"$RULENAME"'") | .RuleId' | cut -d '"' -f2)
+			# RULENAME=$(aws waf list-rules --limit 99 --output=json 2>&1 | jq '.Rules | .[] | .Name' | grep "$CONDITIONNAME" | cut -d '"' -f2)
+			# RULEID=$(aws waf list-rules --limit 99 --output=json 2>&1 | jq '.Rules | .[] | select(.Name=="'"$RULENAME"'") | .RuleId' | cut -d '"' -f2)
 			# echo
 			# echo "====================================================="
 			# echo "Deleting Rule Name $RULENAME, Rule ID $RULEID"
 			# echo "====================================================="
-			# DELETERULE=$(aws waf delete-rule --rule-id "$RULEID" --profile $profile 2>&1)
+			# DELETERULE=$(aws waf delete-rule --rule-id "$RULEID" 2>&1)
 			# if [ ! $? -eq 0 ]; then
 			# 	fail "$DELETERULE"
 			# else
@@ -580,7 +587,7 @@ function WAF(){
 			# echo "====================================================="
 			# echo "Deleting Set $CONDITIONNAME, Set ID $IPSETID"
 			# echo "====================================================="
-			# DELETESET=$(aws waf delete-ip-set --ip-set-id "$IPSETID" --profile $profile 2>&1)
+			# DELETESET=$(aws waf delete-ip-set --ip-set-id "$IPSETID" 2>&1)
 			# if [ ! $? -eq 0 ]; then
 			# 	fail "$DELETESET"
 			# else
@@ -588,7 +595,7 @@ function WAF(){
 			# 	# echo
 			# 	# echo "====================================================="
 			# 	# echo "Creating Security Group "$GROUPNAME
-			# 	# GROUPID=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCRIPTION" --vpc-id $VPCID --profile $profile 2>&1)
+			# 	# GROUPID=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCRIPTION" --vpc-id $VPCID 2>&1)
 			# 	# echo $GROUPID
 			# 	# aws ec2 create-tags --resources $(aws ec2 describe-security-groups --output=json | jq '.SecurityGroups | .[] | select(.GroupName=="$GROUPNAME") | .GroupId' | cut -d '"' -f2) --tags Key=Name,Value="$GROUPNAME"
 			# 	# echo "====================================================="
@@ -596,7 +603,7 @@ function WAF(){
 
 # Ensure AWS profile has necessary permissions
 function preflightChecks(){
-	ListIPSets=$(aws waf list-ip-sets --limit 99 --output=json --profile $profile 2>&1)
+	ListIPSets=$(aws waf list-ip-sets --limit 99 --output=json 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$ListIPSets"
 	fi

--- a/wafv2-web-acl-pingdom.sh
+++ b/wafv2-web-acl-pingdom.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./aws-profile.sh
+source "$SCRIPT_DIR/aws-profile.sh"
+aws_profile_prepare_args "$@" || exit 1
+set -- "${AWS_SCRIPT_LEGACY_ARGS[@]}"
+
+
 # This script will Manage WAFV2 Web ACL to allow current Pingdom probe server IPs
 # Allows creating or updating AWS WAFV2 IP Addresses Set and Web ACLs
 # Saves a list of current Pingdom probe server IPs in the file iplist
@@ -150,7 +157,7 @@ function CreateIPSet(){
 		--description "Pingdom Probe Server IPs - $WAFSCOPE" \
 		--ip-address-version IPV4 \
 		--addresses "$ADDRESSES" \
-		--profile "$profile" 2>&1)
+ 2>&1)
 	
 	if [ ! $? -eq 0 ]; then
 		if [[ $DEBUGMODE ]]; then
@@ -177,7 +184,7 @@ function CreateIPSet(){
 
 # Get list of all IP Sets
 function ListIPSets(){
-	LISTSETS=$(aws wafv2 list-ip-sets --scope "$WAFSCOPE" --limit 100 --profile "$profile" 2>&1)
+	LISTSETS=$(aws wafv2 list-ip-sets --scope "$WAFSCOPE" --limit 100 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$LISTSETS"
 	fi
@@ -193,7 +200,7 @@ function ListIPSets(){
 
 # Get list of IPs in a single IP Set
 function GetIPSet(){
-	GETSET=$(aws wafv2 get-ip-set --scope $WAFSCOPE --id "$IPSETID" --name "$CONDITIONNAME" --profile $profile 2>&1)
+	GETSET=$(aws wafv2 get-ip-set --scope $WAFSCOPE --id "$IPSETID" --name "$CONDITIONNAME" 2>&1)
 	if [ ! $? -eq 0 ]; then
 		fail "$GETSET"
 	fi
@@ -220,7 +227,7 @@ function UpdateIPSet(){
 		--name "$CONDITIONNAME" \
 		--addresses "$ADDRESSES" \
 		--lock-token "$LOCKTOKEN" \
-		--profile $profile 2>&1)
+ 2>&1)
 	
 	if [ ! $? -eq 0 ]; then
 		fail "$UPDATESET"
@@ -266,7 +273,7 @@ EOF
 		--default-action Block={} \
 		--rules "$RULES" \
 		--visibility-config SampledRequestsEnabled=true,CloudWatchMetricsEnabled=true,MetricName="$CONDITIONNAME" \
-		--profile $profile 2>&1)
+ 2>&1)
 	
 	if [ ! $? -eq 0 ]; then
 		fail "$CREATEACL"
@@ -359,13 +366,13 @@ function WAF(){
 		# You can't delete an IPSet if it's still used in any Rules or if it still includes any IP addresses.
 		# You can't delete a Rule if it's still used in any WebACL objects.
 
-			# RULENAME=$(aws wafv2 list-rules --limit 99 --output=json --profile $profile 2>&1 | jq '.Rules | .[] | .Name' | grep "$CONDITIONNAME" | cut -d '"' -f2)
-			# RULEID=$(aws wafv2 list-rules --limit 99 --output=json --profile $profile 2>&1 | jq '.Rules | .[] | select(.Name=="'"$RULENAME"'") | .RuleId' | cut -d '"' -f2)
+			# RULENAME=$(aws wafv2 list-rules --limit 99 --output=json 2>&1 | jq '.Rules | .[] | .Name' | grep "$CONDITIONNAME" | cut -d '"' -f2)
+			# RULEID=$(aws wafv2 list-rules --limit 99 --output=json 2>&1 | jq '.Rules | .[] | select(.Name=="'"$RULENAME"'") | .RuleId' | cut -d '"' -f2)
 			# echo
 			# echo "====================================================="
 			# echo "Deleting Rule Name $RULENAME, Rule ID $RULEID"
 			# echo "====================================================="
-			# DELETERULE=$(aws wafv2 delete-rule --rule-id "$RULEID" --profile $profile 2>&1)
+			# DELETERULE=$(aws wafv2 delete-rule --rule-id "$RULEID" 2>&1)
 			# if [ ! $? -eq 0 ]; then
 			# 	fail "$DELETERULE"
 			# else
@@ -376,7 +383,7 @@ function WAF(){
 			# echo "====================================================="
 			# echo "Deleting Set $CONDITIONNAME, Set ID $IPSETID"
 			# echo "====================================================="
-			# DELETESET=$(aws wafv2 delete-ip-set --ip-set-id "$IPSETID" --profile $profile 2>&1)
+			# DELETESET=$(aws wafv2 delete-ip-set --ip-set-id "$IPSETID" 2>&1)
 			# if [ ! $? -eq 0 ]; then
 			# 	fail "$DELETESET"
 			# else
@@ -384,7 +391,7 @@ function WAF(){
 			# 	# echo
 			# 	# echo "====================================================="
 			# 	# echo "Creating Security Group "$GROUPNAME
-			# 	# GROUPID=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCRIPTION" --vpc-id $VPCID --profile $profile 2>&1)
+			# 	# GROUPID=$(aws ec2 create-security-group --group-name "$GROUPNAME" --description "$DESCRIPTION" --vpc-id $VPCID 2>&1)
 			# 	# echo $GROUPID
 			# 	# aws ec2 create-tags --resources $(aws ec2 describe-security-groups --output=json | jq '.SecurityGroups | .[] | select(.GroupName=="$GROUPNAME") | .GroupId' | cut -d '"' -f2) --tags Key=Name,Value="$GROUPNAME"
 			# 	# echo "====================================================="


### PR DESCRIPTION
## Summary
- add shared `aws-profile.sh` helper for consistent profile handling across scripts
- support `--profile <name>` / `--profile=<name>` and `AWS_PROFILE`
- preserve backward compatibility with legacy first positional profile argument
- remove duplicated inline `--profile $profile` usage by centralizing profile injection
- document precedence and usage examples in README

## Profile precedence
1. `--profile` flag
2. `AWS_PROFILE` environment variable
3. legacy first positional profile argument
4. default AWS CLI credential/profile chain

## Validation
- `bash equality_test.sh`
- `bash -n` on changed shell scripts
- `shellcheck` run on changed scripts (legacy non-blocking findings remain)

Closes #28
